### PR TITLE
Remove unused/invalid vpc_id from README

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -147,7 +147,6 @@ usage: |-
         name                      = var.name
         attributes                = var.attributes
         tags                      = var.tags
-        vpc_id                    = module.vpc.vpc_id
         subnet_ids                = module.subnets.public_subnet_ids
         instance_types            = var.instance_types
         desired_size              = var.desired_size


### PR DESCRIPTION
Copy-pasting from the readme would give this error without removing this `vpc_id`:

```shell
Error: Unsupported argument

  on eks_with_workers.tf line 92, in module "eks_node_group":
  92:   vpc_id         = module.vpc.vpc_id

An argument named "vpc_id" is not expected here.
```