### PR TITLE
kubeconfig, disk_size and autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -20,6 +20,6 @@ min_size = 2
 
 disk_size = 20
 
-kubeconfig_path = "${HOME}/.kube/config"
+kubeconfig_path = "/.kube/config"
 
 kubernetes_labels = {}

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -20,6 +20,6 @@ min_size = 2
 
 disk_size = 20
 
-kubeconfig_path = "/.kube/config"
+kubeconfig_path = "${HOME}/.kube/config"
 
 kubernetes_labels = {}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -74,5 +74,5 @@ module "eks_node_group" {
   cluster_name       = module.eks_cluster.eks_cluster_id
   kubernetes_version = var.kubernetes_version
   kubernetes_labels  = var.kubernetes_labels
-  disk_size	     = var.disk_size
+  disk_size          = var.disk_size
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -74,4 +74,5 @@ module "eks_node_group" {
   cluster_name       = module.eks_cluster.eks_cluster_id
   kubernetes_version = var.kubernetes_version
   kubernetes_labels  = var.kubernetes_labels
+	disk_size					 = var.disk_size
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -74,5 +74,5 @@ module "eks_node_group" {
   cluster_name       = module.eks_cluster.eks_cluster_id
   kubernetes_version = var.kubernetes_version
   kubernetes_labels  = var.kubernetes_labels
-	disk_size					 = var.disk_size
+  disk_size	     = var.disk_size
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,12 @@ locals {
     var.tags,
     {
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    },
+    {
+      "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+    },
+    {
+      "k8s.io/cluster-autoscaler/enabled" = "true"
     }
   )
 }


### PR DESCRIPTION
Although there are a few more fix required such as

1) Private and Public subnet should be labeled with "kubernetes.io/role/internal" = "1"  "kubernetes.io/role/internal-elb" = "1"  and  accordingly

2) Autoscaler role should be added and attached to worker nodes

3) Ingress Role should be added accordingly so Ingress Controller works

4) EBSCsiDriverIAMPolicy should be added for the future

5) "CloudWatchAgentServerPolicy" should be added for Cloudwatch Container Insights  (Not required but nice to have)

6) External-DNS' required policy can be added 

7) Optional cluster-autoscaler deployment can be made so Node Group AutoScaling can work by default without additional steps 