### PR TITLE
Use splat syntax to return NG underlying resources

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,7 +42,7 @@ module "subnets" {
 }
 
 module "eks_cluster" {
-  source                = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=tags/0.13.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=tags/0.16.0"
   namespace             = var.namespace
   stage                 = var.stage
   name                  = var.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "eks_node_group_arn" {
 
 output "eks_node_group_resources" {
   description = "List of objects containing information about underlying resources of the EKS Node Group"
-  value       = var.enabled ? aws_eks_node_group.default.0.resources : []
+  value       = var.enabled ? aws_eks_node_group.default.*.resources : []
 }
 
 output "eks_node_group_status" {


### PR DESCRIPTION
Hi,
this fixes for me the [issue #7](https://github.com/cloudposse/terraform-aws-eks-node-group/issues/7): 
Unfortunately I could not reproduce the issue by testing the module only.

Since this [PR #22846](https://github.com/hashicorp/terraform/pull/22846) on Terraform itself was merged, I think that the splat syntax is a better approach when looking for resources which instances  could not exist anymore, particularly during a destroy action.

Links:

- https://discuss.hashicorp.com/t/empty-tuple-error-on-modules-that-are-disabled/4544
- https://github.com/hashicorp/terraform/pull/22846

Thank you