### PR TITLE
Add optional variable to transmit "depends_on" dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Available targets:
 | kubernetes_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | string | `null` | no |
 | max_size | Maximum number of worker nodes | number | - | yes |
 | min_size | Minimum number of worker nodes | number | - | yes |
+| module_depends_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | any | `null` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | source_security_group_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | list(string) | `<list>` | no |
@@ -291,6 +292,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 ## Slack Community
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
 
 ## Newsletter
 
@@ -405,6 +410,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-node-group&utm_content=we_love_open_source

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@
 | kubernetes_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | string | `null` | no |
 | max_size | Maximum number of worker nodes | number | - | yes |
 | min_size | Minimum number of worker nodes | number | - | yes |
+| module_depends_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | any | `null` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | source_security_group_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | list(string) | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,10 @@ resource "aws_eks_node_group" "default" {
     aws_iam_role_policy_attachment.amazon_eks_worker_node_policy,
     aws_iam_role_policy_attachment.amazon_eks_worker_node_autoscaler_policy,
     aws_iam_role_policy_attachment.amazon_eks_cni_policy,
-    aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only
+    aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only,
+    # Also allow calling module to create an explicit dependency
+    # This is useful in conjunction with terraform-aws-eks-cluster to ensure
+    # the cluster is fully created and configured before creating any node groups
+    var.module_depends_on
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "source_security_group_ids" {
   default     = []
   description = "Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0)"
 }
+
+variable "module_depends_on" {
+  type        = any
+  default     = null
+  description = "Can be any value desired. Module will wait for this value to be computed before creating node group."
+}


### PR DESCRIPTION
## what
* Add `module_depends_on` variable to allow user to force this module to wait for the creation of an arbitrary resource before creating the node group

## why
* Terraform has a [`depends_on`](https://www.terraform.io/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) feature, but it is not supported for modules and [support is not likely to be added](https://github.com/hashicorp/terraform/issues/1178). This provides equivalent functionality, and is useful for the situation where you want to operate on a newly created cluster before creating node groups.

