### PR TITLE
Ignore the desired size when autoscaled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,10 @@ resource "aws_eks_node_group" "default" {
     min_size     = var.min_size
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   dynamic "remote_access" {
     for_each = var.ec2_ssh_key != null && var.ec2_ssh_key != "" ? ["true"] : []
     content {
@@ -168,7 +172,8 @@ resource "aws_eks_node_group" "autoscaled" {
   }
 
   lifecycle {
-    ignore_changes = [scaling_config.0.desired_size]
+    create_before_destroy = true
+    ignore_changes        = [scaling_config.0.desired_size]
   }
 
   dynamic "remote_access" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,20 +10,20 @@ output "eks_node_group_role_name" {
 
 output "eks_node_group_id" {
   description = "EKS Cluster name and EKS Node Group name separated by a colon"
-  value       = join("", aws_eks_node_group.default.*.id)
+  value       = var.enable_cluster_autoscaler ? join("", aws_eks_node_group.autoscaled.*.id) : join("", aws_eks_node_group.default.*.id)
 }
 
 output "eks_node_group_arn" {
   description = "Amazon Resource Name (ARN) of the EKS Node Group"
-  value       = join("", aws_eks_node_group.default.*.arn)
+  value       = var.enable_cluster_autoscaler ? join("", aws_eks_node_group.autoscaled.*.arn) : join("", aws_eks_node_group.default.*.arn)
 }
 
 output "eks_node_group_resources" {
   description = "List of objects containing information about underlying resources of the EKS Node Group"
-  value       = var.enabled ? aws_eks_node_group.default.*.resources : []
+  value       = var.enable_cluster_autoscaler ? concat([], aws_eks_node_group.autoscaled.*.resources) : concat([], aws_eks_node_group.default.*.resources)
 }
 
 output "eks_node_group_status" {
   description = "Status of the EKS Node Group"
-  value       = join("", aws_eks_node_group.default.*.status)
+  value       = var.enable_cluster_autoscaler ? join("", aws_eks_node_group.autoscaled.*.status) : join("", aws_eks_node_group.default.*.status)
 }


### PR DESCRIPTION
## why
Ignore the desired size when the node group's autoscaling group is autoscaled externally (i.e. via the Kubernetes cluster autoscaler).

## what
Since it's not possible to make the lifecycle dynamic and conditionally ignore changes based on the
autoscaling configuration, manage differnent node group resources tailored for the different use
cases.

## references
- closes #12
- https://github.com/hashicorp/terraform/issues/24188
- https://discuss.hashicorp.com/t/dynamic-lifecycle-ignore-changes/4579/4

## BREAKING CHANGE
If already enabled the cluster autoscaler, the node group resources will be
replaced, since the default node group is no longer the one with the autoscaling enabled.
