### PR TITLE
Ignore external changes to desired group size

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ For automated tests of the complete example using [bats](https://github.com/bats
       name                      = var.name
       attributes                = var.attributes
       tags                      = var.tags
-      vpc_id                    = module.vpc.vpc_id
       subnet_ids                = module.subnets.public_subnet_ids
       instance_types            = var.instance_types
       desired_size              = var.desired_size
@@ -191,45 +190,60 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.3 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| ami_release_version | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | string | `null` | no |
-| ami_type | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | string | `AL2_x86_64` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| cluster_name | The name of the EKS cluster | string | - | yes |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| desired_size | Desired number of worker nodes | number | - | yes |
-| disk_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | number | `20` | no |
-| ec2_ssh_key | SSH key name that should be used to access the worker nodes | string | `null` | no |
-| enable_cluster_autoscaler | Whether to enable node group to scale the Auto Scaling Group | bool | `false` | no |
-| enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | bool | `true` | no |
-| existing_workers_role_policy_arns | List of existing policy ARNs that will be attached to the workers default role on creation | list(string) | `<list>` | no |
-| existing_workers_role_policy_arns_count | Count of existing policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | number | `0` | no |
-| instance_types | Set of instance types associated with the EKS Node Group. Defaults to ["t3.medium"]. Terraform will only perform drift detection if a configuration value is provided | list(string) | - | yes |
-| kubernetes_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | map(string) | `<map>` | no |
-| kubernetes_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | string | `null` | no |
-| max_size | Maximum number of worker nodes | number | - | yes |
-| min_size | Minimum number of worker nodes | number | - | yes |
-| module_depends_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | any | `null` | no |
-| name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
-| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
-| source_security_group_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | list(string) | `<list>` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
-| subnet_ids | A list of subnet IDs to launch resources in | list(string) | - | yes |
-| tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map(string) | `<map>` | no |
+|------|-------------|------|---------|:--------:|
+| ami\_release\_version | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | `string` | `null` | no |
+| ami\_type | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | `string` | `"AL2_x86_64"` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| cluster\_name | The name of the EKS cluster | `string` | n/a | yes |
+| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| desired\_size | Desired number of worker nodes (external changes ignored) | `number` | n/a | yes |
+| disk\_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | `number` | `20` | no |
+| ec2\_ssh\_key | SSH key name that should be used to access the worker nodes | `string` | `null` | no |
+| enable\_cluster\_autoscaler | Whether to enable node group to scale the Auto Scaling Group | `bool` | `false` | no |
+| enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| existing\_workers\_role\_policy\_arns | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
+| existing\_workers\_role\_policy\_arns\_count | Count of existing policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | `number` | `0` | no |
+| instance\_types | Set of instance types associated with the EKS Node Group. Defaults to ["t3.medium"]. Terraform will only perform drift detection if a configuration value is provided | `list(string)` | n/a | yes |
+| kubernetes\_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `{}` | no |
+| kubernetes\_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
+| max\_size | Maximum number of worker nodes | `number` | n/a | yes |
+| min\_size | Minimum number of worker nodes | `number` | n/a | yes |
+| module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
+| name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
+| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | `string` | `""` | no |
+| subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
+| tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| eks_node_group_arn | Amazon Resource Name (ARN) of the EKS Node Group |
-| eks_node_group_id | EKS Cluster name and EKS Node Group name separated by a colon |
-| eks_node_group_resources | List of objects containing information about underlying resources of the EKS Node Group |
-| eks_node_group_role_arn | ARN of the worker nodes IAM role |
-| eks_node_group_role_name | Name of the worker nodes IAM role |
-| eks_node_group_status | Status of the EKS Node Group |
+| eks\_node\_group\_arn | Amazon Resource Name (ARN) of the EKS Node Group |
+| eks\_node\_group\_id | EKS Cluster name and EKS Node Group name separated by a colon |
+| eks\_node\_group\_resources | List of objects containing information about underlying resources of the EKS Node Group |
+| eks\_node\_group\_role\_arn | ARN of the worker nodes IAM role |
+| eks\_node\_group\_role\_name | Name of the worker nodes IAM role |
+| eks\_node\_group\_status | Status of the EKS Node Group |
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -147,7 +147,6 @@ usage: |-
         name                      = var.name
         attributes                = var.attributes
         tags                      = var.tags
-        vpc_id                    = module.vpc.vpc_id
         subnet_ids                = module.subnets.public_subnet_ids
         instance_types            = var.instance_types
         desired_size              = var.desired_size

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,40 +1,55 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.3 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| ami_release_version | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | string | `null` | no |
-| ami_type | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | string | `AL2_x86_64` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| cluster_name | The name of the EKS cluster | string | - | yes |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| desired_size | Desired number of worker nodes | number | - | yes |
-| disk_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | number | `20` | no |
-| ec2_ssh_key | SSH key name that should be used to access the worker nodes | string | `null` | no |
-| enable_cluster_autoscaler | Whether to enable node group to scale the Auto Scaling Group | bool | `false` | no |
-| enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | bool | `true` | no |
-| existing_workers_role_policy_arns | List of existing policy ARNs that will be attached to the workers default role on creation | list(string) | `<list>` | no |
-| existing_workers_role_policy_arns_count | Count of existing policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | number | `0` | no |
-| instance_types | Set of instance types associated with the EKS Node Group. Defaults to ["t3.medium"]. Terraform will only perform drift detection if a configuration value is provided | list(string) | - | yes |
-| kubernetes_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | map(string) | `<map>` | no |
-| kubernetes_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | string | `null` | no |
-| max_size | Maximum number of worker nodes | number | - | yes |
-| min_size | Minimum number of worker nodes | number | - | yes |
-| module_depends_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | any | `null` | no |
-| name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
-| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
-| source_security_group_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | list(string) | `<list>` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
-| subnet_ids | A list of subnet IDs to launch resources in | list(string) | - | yes |
-| tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map(string) | `<map>` | no |
+|------|-------------|------|---------|:--------:|
+| ami\_release\_version | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | `string` | `null` | no |
+| ami\_type | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | `string` | `"AL2_x86_64"` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| cluster\_name | The name of the EKS cluster | `string` | n/a | yes |
+| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| desired\_size | Desired number of worker nodes (external changes ignored) | `number` | n/a | yes |
+| disk\_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | `number` | `20` | no |
+| ec2\_ssh\_key | SSH key name that should be used to access the worker nodes | `string` | `null` | no |
+| enable\_cluster\_autoscaler | Whether to enable node group to scale the Auto Scaling Group | `bool` | `false` | no |
+| enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| existing\_workers\_role\_policy\_arns | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
+| existing\_workers\_role\_policy\_arns\_count | Count of existing policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | `number` | `0` | no |
+| instance\_types | Set of instance types associated with the EKS Node Group. Defaults to ["t3.medium"]. Terraform will only perform drift detection if a configuration value is provided | `list(string)` | n/a | yes |
+| kubernetes\_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `{}` | no |
+| kubernetes\_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
+| max\_size | Maximum number of worker nodes | `number` | n/a | yes |
+| min\_size | Minimum number of worker nodes | `number` | n/a | yes |
+| module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
+| name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
+| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | `string` | `""` | no |
+| subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
+| tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| eks_node_group_arn | Amazon Resource Name (ARN) of the EKS Node Group |
-| eks_node_group_id | EKS Cluster name and EKS Node Group name separated by a colon |
-| eks_node_group_resources | List of objects containing information about underlying resources of the EKS Node Group |
-| eks_node_group_role_arn | ARN of the worker nodes IAM role |
-| eks_node_group_role_name | Name of the worker nodes IAM role |
-| eks_node_group_status | Status of the EKS Node Group |
+| eks\_node\_group\_arn | Amazon Resource Name (ARN) of the EKS Node Group |
+| eks\_node\_group\_id | EKS Cluster name and EKS Node Group name separated by a colon |
+| eks\_node\_group\_resources | List of objects containing information about underlying resources of the EKS Node Group |
+| eks\_node\_group\_role\_arn | ARN of the worker nodes IAM role |
+| eks\_node\_group\_role\_name | Name of the worker nodes IAM role |
+| eks\_node\_group\_status | Status of the EKS Node Group |
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "ec2_ssh_key" {
 
 variable "desired_size" {
   type        = number
-  description = "Desired number of worker nodes"
+  description = "Desired number of worker nodes (external changes ignored)"
 }
 
 variable "max_size" {


### PR DESCRIPTION
## what
* Ignore external changes to desired group size, closes #12 
* Use current "partition" in hard-coded ARNs, closes #16, thank you @woz5999
* Remove erroneous assignment from README, closes #5, thank you @MPV

## why
* It is expected that the desired size of a group will be changed by some sort of external scaling process and it should not be reset by Terraform. If you want to control the size of the node group via Terraform, you can control it by setting `min_size` and `max_size` to the size you want.
* Support GovCloud and China

