### PR TITLE
Bumping AWS provider version to ~> 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | local | ~> 1.3 |
 | template | ~> 2.0 |
 
@@ -185,7 +185,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | local | ~> 1.3 |
 | template | ~> 2.0 |
 
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws        = "~> 2.0"
+    aws        = "~> 3.0"
     template   = "~> 2.0"
     null       = "~> 2.0"
     local      = "~> 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = "~> 3.0"
     template = "~> 2.0"
     local    = "~> 1.3"
   }


### PR DESCRIPTION
## what
* Bumping our AWS provider to version 3

## why
* Allows us to take advantage of some newer Terraform features when deploying EKS
* For example, this will provide us with the ability to specify custom launch templates in `aws_eks_node_group`

## references

#### https://github.com/aws/containers-roadmap/issues/585