### PR TITLE
Added support for custom AMIs and node taints and other kubelet args

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -31,3 +31,5 @@ disk_size = 20
 kubernetes_labels = {}
 
 before_cluster_joining_userdata = "echo foo"
+
+node_taints = ["dedicated=special:NoSchedule"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -90,6 +90,7 @@ module "eks_node_group" {
   kubernetes_version = var.kubernetes_version
   kubernetes_labels  = var.kubernetes_labels
   disk_size          = var.disk_size
+  node_taints        = var.node_taints
 
   before_cluster_joining_userdata = var.before_cluster_joining_userdata
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -116,3 +116,21 @@ variable "before_cluster_joining_userdata" {
   default     = ""
   description = "Additional commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production"
 }
+
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = "Can be used to specify a custom Amazon Machine Image (AMI) id. If not specified the default AMI for the kubernetes version will be used"
+}
+
+variable "kubelet_extra_args" {
+  type        = list(string)
+  default     = []
+  description = "Can be used to specify additional kubelet arguments, other than taint and labels which are provided though other variables"
+}
+
+variable "node_taints" {
+  type        = list(string)
+  default     = []
+  description = "Can be used to specify node taints in the following format: key=value:effect, e.g: dedicated=special:NoSchedule"
+}

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -2,9 +2,134 @@ MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
 --//
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash
+Content-Type: text/x-shellscript
+Content-Type: charset="us-ascii"
 
 ${before_cluster_joining_userdata}
 
---//--
+cat << 'EOF' > /etc/eks/extra_args.sh
+#!/usr/bin/env bash
+set -ex +u
+
+function prepare_lines() {
+  local KUBELET_EXTRA_ARGS="$1"
+
+  # Break each argument into its own line, and replace the first '=' with '%' for easier processing later
+  # Example output:
+  # --register-with-taints%dedicated=test:NoSchedule
+  # --node-labels%eks.amazonaws.com/nodegroup=test-mng,other.label=other
+  #
+  local EXTRA_ARGS_LINES=$(echo "$KUBELET_EXTRA_ARGS" | xargs -d' ' -I{} bash -c 'echo "{}" | sed "0,/=/s//%/"')
+
+  # Remove blank lines
+  # Example output:
+  # --register-with-taints%dedicated=test:NoSchedule
+  # --node-labels%eks.amazonaws.com/nodegroup=test-mng,other.label=other
+  local EXTRA_ARGS_LINES=$(echo "$EXTRA_ARGS_LINES" | sed '/^$/d')
+
+  echo "$EXTRA_ARGS_LINES"
+}
+
+# 30-kubelet-extra-args.conf example:
+# [Service]
+# Environment='KUBELET_EXTRA_ARGS=--register-with-taints="dedicated=test:NoSchedule" --node-labels=eks.amazonaws.com/nodegroup=test-mng,other.label=other'
+
+# Get the last line and cut out the part between the single quotes
+# Example output:
+# KUBELET_EXTRA_ARGS=--register-with-taints="dedicated=test:NoSchedule" --node-labels=eks.amazonaws.com/nodegroup=test-mng,other.label=other
+ENVIRONMENT=$(tail -n1 /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf | cut -d\' -f2)
+
+# Get the value of KUBELET_EXTRA_ARGS
+# Example output:
+# --register-with-taints="dedicated=test:NoSchedule" --node-labels=eks.amazonaws.com/nodegroup=test-mng,other.label=other
+KUBELET_EXTRA_ARGS=$(echo "$ENVIRONMENT" | cut -d= -f 2-)
+
+# Declare an associate array for later use
+declare -A EXTRA_ARGS=()
+
+# Loop over each of the lines and add each key value pair to the associate array
+# Example output:
+# [--node-labels]="eks.amazonaws.com/nodegroup=test-mng,other.label=other"
+# [--register-with-taints]="dedicated=test:NoSchedule"
+while IFS=% read -r key value; do
+  EXTRA_ARGS[$key]="$value"
+done < <(prepare_lines "$KUBELET_EXTRA_ARGS")
+
+# Additional args from Terraform, separated by spaces
+# Example:
+# --log-file=/tmp/kubelet.log
+KUBELET_NEW_ARGS='${kubelet_extra_args}'
+
+if [[ -n "$KUBELET_NEW_ARGS" ]]; then
+  # Declare an associate array for later use
+  declare -A NEW_EXTRA_ARGS=()
+
+  # Loop over each of the lines and add each key value pair to the associate array
+  # Example output:
+  # [--log-file]="/tmp/kubelet.log"
+  # [--hostname-override]="dedicated-node-az1"
+  while IFS=% read -r key value; do
+    NEW_EXTRA_ARGS[$key]="$value"
+  done < <(prepare_lines "$KUBELET_NEW_ARGS")
+
+  for KEY in "$${!NEW_EXTRA_ARGS[@]}"; do
+    # If there is existing values, add a comma before adding the new values
+    test -n "$${EXTRA_ARGS[$KEY]}" && EXTRA_ARGS[$KEY]+=","
+    EXTRA_ARGS[$KEY]+="$${NEW_EXTRA_ARGS[$KEY]}"
+  done
+fi
+
+# Additional taints from Terraform, separated by commas
+# Example:
+# dedicated=new-test:NoSchedule
+NEW_TAINTS='${node_taints}'
+
+# Additional labels from Terraform, separated by commas
+# Example:
+# new.label=new
+NEW_LABELS='${node_labels}'
+
+# Add the new taints to the associate array, if defined
+# Example output:
+# [--node-labels]="eks.amazonaws.com/nodegroup=test-mng,other.label=other"
+# [--register-with-taints]="dedicated=test:NoSchedule,dedicated=new-test:NoSchedule"
+if [[ -n "$NEW_TAINTS" ]]; then
+  # If there is existing taints, add a comma before adding the new taints
+  test -n "$${EXTRA_ARGS['--register-with-taints']}" && EXTRA_ARGS['--register-with-taints']+=","
+  EXTRA_ARGS['--register-with-taints']+="$NEW_TAINTS"
+fi
+
+# Add the new labels to the associate array, if defined
+# Example output:
+# [--node-labels]="eks.amazonaws.com/nodegroup=test-mng,other.label=other,new.label=new"
+# [--register-with-taints]="dedicated=test:NoSchedule,dedicated=new-test:NoSchedule"
+if [[ -n "$NEW_LABELS" ]]; then
+  # If there is existing labels, add a comma before adding the new labels
+  test -n "$${EXTRA_ARGS['--node-labels']}" && EXTRA_ARGS['--node-labels']+=","
+  EXTRA_ARGS['--node-labels']+="$NEW_LABELS"
+fi
+
+# Build string from the joined arguments to add to the output file
+# Example:
+# --log-file=/tmp/kubelet.log --hostname-override=dedicated-node-az1 --node-labels=eks.amazonaws.com/nodegroup=test-mng,other.label=other,new.label=new --register-with-taints=dedicated=test:NoSchedule,dedicated=new-test:NoSchedule
+NEW_KUBELET_EXTRA_ARGS=""
+for i in "$${!EXTRA_ARGS[@]}";do
+  NEW_KUBELET_EXTRA_ARGS+=$(printf "%s=%s " "$i" "$${EXTRA_ARGS[$i]}")
+done
+
+# Remove the trailing space
+NEW_KUBELET_EXTRA_ARGS=$(echo "$NEW_KUBELET_EXTRA_ARGS" | xargs)
+
+# Write the final output file
+# Example:
+# [Service]
+# Environment='KUBELET_EXTRA_ARGS=--log-file=/tmp/kubelet.log --hostname-override=dedicated-node-az1 --node-labels=eks.amazonaws.com/nodegroup=test-mng,other.label=other,new.label=new --register-with-taints=dedicated=test:NoSchedule,dedicated=new-test:NoSchedule'
+cat <<CONF > /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+[Service]
+Environment='KUBELET_EXTRA_ARGS=$${NEW_KUBELET_EXTRA_ARGS}'
+CONF
+EOF
+
+# Execute the hook script before starting the services
+sed -i "/^systemctl daemon-reload\$/i . /etc/eks/extra_args.sh" /etc/eks/bootstrap.sh
+--//

--- a/userdata_ami.tpl
+++ b/userdata_ami.tpl
@@ -1,0 +1,5 @@
+Content-Type: text/x-shellscript
+Content-Type: charset="us-ascii"
+
+/etc/eks/bootstrap.sh ${cluster_name} --kubelet-extra-args "--node-labels=eks.amazonaws.com/nodegroup=${node_group_name},eks.amazonaws.com/nodegroup-image=${ami_id}"
+--//

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,21 @@ variable "before_cluster_joining_userdata" {
   default     = ""
   description = "Additional commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production"
 }
+
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = "Can be used to specify a custom Amazon Machine Image (AMI) id. If not specified the default AMI for the kubernetes version will be used"
+}
+
+variable "kubelet_extra_args" {
+  type        = list(string)
+  default     = []
+  description = "Can be used to specify additional kubelet arguments, other than taint and labels which are provided though other variables"
+}
+
+variable "node_taints" {
+  type        = list(string)
+  default     = []
+  description = "Can be used to specify node taints in the following format: key=value:effect, e.g: dedicated=special:NoSchedule"
+}


### PR DESCRIPTION
## What
These changes are in relation to the PR about launch configurations (#27). This PR is circumventing the problem with not being able to specify the `KUBELET_EXTRA_ARGS` in user_data when not specifying `ami_id`, as noted in the PR which rolled back some of the changes (#28). 
As AWS appends a call to the `/etc/eks/bootstrap.sh` to the user_data, it is necessary to modify the bootstrap file to include the changes to the config.  This is done by  adding a hook [right before the services are started](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh#L340), which allows for updates to the `/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf` file.

Here is an outline of what is happening the hook script:
* Read out the existing configuration from `30-kubelet-extra-args.conf`
* Parse the arguments in `KUBELET_EXTRA_ARGS` into an associative array
* Parse the arguments from the user supplied `KUBELET_NEW_ARGS` into the array
* Add taints from the user supplied `NEW_TAINTS` to the entry `--register-with-taints` in the array
* Add labels from the user supplied `NEW_LABELS` to the entry `--node-labels` in the array
* Combine the entries from the array into a string, and write it back to `30-kubelet-extra-args.conf`

This preserve the arguments that the `bootstrap.sh` adds to `KUBELET_EXTRA_ARGS`, while still being able to add user specified arguments.

A minor change is that I had to make to the way the security groups are added to a node group, as I got an error `Remote access configuration cannot be specified with a launch template`. They are now added to the launch configuration by using `vpc_security_group_ids`. By specifying this, it overwrites the security group AWS adds normally, that allows for communication with the control plane, which is why I had to add a data source for the `aws_eks_cluster` in order to retrieve the security group id. This change can be omitted in this PR and added as a separate PR if you like.

## Why
* This is needed in order to use managed node groups with node taints, without having to specifying an `ami_id`.

## References
* aws/containers-roadmap#585
* https://aws.amazon.com/blogs/containers/introducing-launch-template-and-custom-ami-support-in-amazon-eks-managed-node-groups/
* https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh


PS: I have not updated tests and documentation yet, as I wanted to get your reaction to the changes before continuing. 
The changes have been tested with and without specifying an `ami_id`, and with and without specifying an `ec2_ssh_key` by creating clusters using Terraform in AWS.