### PR TITLE
fix: autoscaler renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Available targets:
 | subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | userdata\_override\_base64 | Many features of this module rely on the `bootstrap.sh` provided with Amazon Linux, and this module<br>may generate "user data" that expects to find that script. If you want to use an AMI that is not<br>compatible with the Amazon Linux `bootstrap.sh` initialization, then use `userdata_override_base64` to provide<br>your own (Base64 encoded) user data. Use "" to prevent any user data from being set.<br><br>Setting `userdata_override_base64` disables `kubernetes_taints`, `kubelet_additional_options`,<br>`before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`. | `string` | `null` | no |
-| worker\_role\_autoscale\_iam\_enabled | If true, the worker IAM role will be authorized to perform autoscaling operations. Not recommended.<br>Use [EKS IAM role for cluster autoscaler service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) instead. | `bool` | `false` | no |
+| worker\_role\_autoscaler\_iam\_enabled | If true, the worker IAM role will be authorized to perform autoscaling operations. Not recommended.<br>Use [EKS IAM role for cluster autoscaler service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) instead. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -63,7 +63,7 @@
 | subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | userdata\_override\_base64 | Many features of this module rely on the `bootstrap.sh` provided with Amazon Linux, and this module<br>may generate "user data" that expects to find that script. If you want to use an AMI that is not<br>compatible with the Amazon Linux `bootstrap.sh` initialization, then use `userdata_override_base64` to provide<br>your own (Base64 encoded) user data. Use "" to prevent any user data from being set.<br><br>Setting `userdata_override_base64` disables `kubernetes_taints`, `kubelet_additional_options`,<br>`before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`. | `string` | `null` | no |
-| worker\_role\_autoscale\_iam\_enabled | If true, the worker IAM role will be authorized to perform autoscaling operations. Not recommended.<br>Use [EKS IAM role for cluster autoscaler service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) instead. | `bool` | `false` | no |
+| worker\_role\_autoscaler\_iam\_enabled | If true, the worker IAM role will be authorized to perform autoscaling operations. Not recommended.<br>Use [EKS IAM role for cluster autoscaler service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) instead. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/iam.tf
+++ b/iam.tf
@@ -20,8 +20,8 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-data "aws_iam_policy_document" "amazon_eks_worker_node_autoscale_policy" {
-  count = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
+data "aws_iam_policy_document" "amazon_eks_worker_node_autoscaler_policy" {
+  count = (local.enabled && var.worker_role_autoscaler_iam_enabled) ? 1 : 0
   statement {
     sid = "AllowToScaleEKSNodeGroupAutoScalingGroup"
 
@@ -41,10 +41,10 @@ data "aws_iam_policy_document" "amazon_eks_worker_node_autoscale_policy" {
   }
 }
 
-resource "aws_iam_policy" "amazon_eks_worker_node_autoscale_policy" {
-  count  = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
-  name   = "${module.label.id}-autoscale"
-  policy = join("", data.aws_iam_policy_document.amazon_eks_worker_node_autoscale_policy.*.json)
+resource "aws_iam_policy" "amazon_eks_worker_node_autoscaler_policy" {
+  count  = (local.enabled && var.worker_role_autoscaler_iam_enabled) ? 1 : 0
+  name   = "${module.label.id}-autoscaler"
+  policy = join("", data.aws_iam_policy_document.amazon_eks_worker_node_autoscaler_policy.*.json)
 }
 
 resource "aws_iam_role" "default" {
@@ -60,9 +60,9 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
   role       = join("", aws_iam_role.default.*.name)
 }
 
-resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_autoscale_policy" {
-  count      = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
-  policy_arn = join("", aws_iam_policy.amazon_eks_worker_node_autoscale_policy.*.arn)
+resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_autoscaler_policy" {
+  count      = (local.enabled && var.worker_role_autoscaler_iam_enabled) ? 1 : 0
+  policy_arn = join("", aws_iam_policy.amazon_eks_worker_node_autoscaler_policy.*.arn)
   role       = join("", aws_iam_role.default.*.name)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ resource "aws_eks_node_group" "default" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_worker_node_policy,
-    aws_iam_role_policy_attachment.amazon_eks_worker_node_autoscale_policy,
+    aws_iam_role_policy_attachment.amazon_eks_worker_node_autoscaler_policy,
     aws_iam_role_policy_attachment.amazon_eks_cni_policy,
     aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only,
     aws_security_group.remote_access,
@@ -231,7 +231,7 @@ resource "aws_eks_node_group" "cbd" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_worker_node_policy,
-    aws_iam_role_policy_attachment.amazon_eks_worker_node_autoscale_policy,
+    aws_iam_role_policy_attachment.amazon_eks_worker_node_autoscaler_policy,
     aws_iam_role_policy_attachment.amazon_eks_cni_policy,
     aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only,
     aws_security_group.remote_access,

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "cluster_autoscaler_enabled" {
   default     = null
 }
 
-variable "worker_role_autoscale_iam_enabled" {
+variable "worker_role_autoscaler_iam_enabled" {
   type        = bool
   default     = false
   description = <<-EOT

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 0.13.3"
+  experiments = [variable_validation]
 
   required_providers {
     aws      = ">= 3.0"


### PR DESCRIPTION
## what
* Switch to `autoscaler` from `autoscale`
* Added `variable_validation` experiment for green tests

## why
* Seems like it was unintended during refactor

## references
* Closes #38 

