### PR TITLE
add permissions_boundary for IAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Available targets:
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | resources\_to\_tag | List of auto-launched resource types to tag. Valid types are "instance", "volume", "elastic-gpu", "spot-instances-request". | `list(string)` | `[]` | no |
 | source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) to the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -56,6 +56,7 @@
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | resources\_to\_tag | List of auto-launched resource types to tag. Valid types are "instance", "volume", "elastic-gpu", "spot-instances-request". | `list(string)` | `[]` | no |
 | source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) to the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -48,11 +48,11 @@ resource "aws_iam_policy" "amazon_eks_worker_node_autoscale_policy" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = local.enabled ? 1 : 0
-  name               = module.label.id
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
-  permissions_boundary  = var.permissions_boundary
-  tags               = module.label.tags
+  count                = local.enabled ? 1 : 0
+  name                 = module.label.id
+  assume_role_policy   = join("", data.aws_iam_policy_document.assume_role.*.json)
+  permissions_boundary = var.permissions_boundary
+  tags                 = module.label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {

--- a/iam.tf
+++ b/iam.tf
@@ -51,6 +51,7 @@ resource "aws_iam_role" "default" {
   count              = local.enabled ? 1 : 0
   name               = module.label.id
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
+  permissions_boundary  = var.permissions_boundary
   tags               = module.label.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -247,3 +247,9 @@ variable "userdata_override_base64" {
     `before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`.
     EOT
 }
+
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## what
permissions_boundary policy for IAM Role created for EKS node group to restrict the IAM permissions on the account wide


## why
IAM role can apply a permissions_boundary when there is a company-wide policy applied



## references
https://github.com/cloudposse/terraform-aws-eks-node-group/issues/42
