### PR TITLE
feat: Implement optional additional principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Available targets:
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
+| map\_additional\_assume\_role\_principals | List of principals that should be added to the assume role policy document. | <pre>list(object({<br>    type        = string<br>    identifiers = list(string)<br>  }))</pre> | `[]` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |
 | min\_size | Minimum number of worker nodes | `number` | n/a | yes |
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -54,6 +54,7 @@
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
+| map\_additional\_assume\_role\_principals | List of principals that should be added to the assume role policy document. | <pre>list(object({<br>    type        = string<br>    identifiers = list(string)<br>  }))</pre> | `[]` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |
 | min\_size | Minimum number of worker nodes | `number` | n/a | yes |
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -18,6 +18,21 @@ data "aws_iam_policy_document" "assume_role" {
       identifiers = ["ec2.amazonaws.com"]
     }
   }
+
+  dynamic "statement" {
+    for_each = var.map_additional_assume_role_principals
+    iterator = "principal"
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = principal.value.type
+        identifiers = principal.value.identifiers
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "amazon_eks_worker_node_autoscale_policy" {

--- a/iam.tf
+++ b/iam.tf
@@ -21,15 +21,14 @@ data "aws_iam_policy_document" "assume_role" {
 
   dynamic "statement" {
     for_each = var.map_additional_assume_role_principals
-    iterator = "principal"
 
     content {
       effect  = "Allow"
       actions = ["sts:AssumeRole"]
 
       principals {
-        type        = principal.value.type
-        identifiers = principal.value.identifiers
+        type        = statement.value.type
+        identifiers = statement.value.identifiers
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ data "aws_eks_cluster" "this" {
 
 # Support keeping 2 node groups in sync by extracting common variable settings
 locals {
-  ng_needs_remote_access = local.have_ssh_key && !local.use_launch_template
+  ng_needs_remote_access = local.have_ssh_key && ! local.use_launch_template
   ng = {
     cluster_name    = var.cluster_name
     node_role_arn   = join("", aws_iam_role.default.*.arn)
@@ -126,7 +126,7 @@ resource "random_pet" "cbd" {
 # WARNING TO MAINTAINERS: both node groups should be kept exactly in sync
 # except for count, lifecycle, and node_group_name.
 resource "aws_eks_node_group" "default" {
-  count           = local.enabled && !var.create_before_destroy ? 1 : 0
+  count           = local.enabled && ! var.create_before_destroy ? 1 : 0
   node_group_name = module.label.id
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ data "aws_eks_cluster" "this" {
 
 # Support keeping 2 node groups in sync by extracting common variable settings
 locals {
-  ng_needs_remote_access = local.have_ssh_key && ! local.use_launch_template
+  ng_needs_remote_access = local.have_ssh_key && !local.use_launch_template
   ng = {
     cluster_name    = var.cluster_name
     node_role_arn   = join("", aws_iam_role.default.*.arn)
@@ -126,7 +126,7 @@ resource "random_pet" "cbd" {
 # WARNING TO MAINTAINERS: both node groups should be kept exactly in sync
 # except for count, lifecycle, and node_group_name.
 resource "aws_eks_node_group" "default" {
-  count           = local.enabled && ! var.create_before_destroy ? 1 : 0
+  count           = local.enabled && !var.create_before_destroy ? 1 : 0
   node_group_name = module.label.id
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -276,7 +276,7 @@ variable "launch_template_disk_encryption_kms_key_id" {
 }
 
 variable "map_additional_assume_role_principals" {
-  description = "List of principals that should be added the assume role policy document."
+  description = "List of principals that should be added to the assume role policy document."
   type = list(object({
     type        = string
     identifiers = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -219,7 +219,7 @@ variable "resources_to_tag" {
   default     = []
   validation {
     condition = (
-      length(compact([for r in var.resources_to_tag : r if ! contains(["instance", "volume", "elastic-gpu", "spot-instances-request"], r)])) == 0
+      length(compact([for r in var.resources_to_tag : r if !contains(["instance", "volume", "elastic-gpu", "spot-instances-request"], r)])) == 0
     )
     error_message = "Invalid resource type in `resources_to_tag`. Valid types are \"instance\", \"volume\", \"elastic-gpu\", \"spot-instances-request\"."
   }
@@ -275,3 +275,11 @@ variable "launch_template_disk_encryption_kms_key_id" {
   description = "Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true"
 }
 
+variable "map_additional_assume_role_principals" {
+  description = "List of principals that should be added the assume role policy document."
+  type = list(object({
+    type        = string
+    identifiers = list(string)
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -219,7 +219,7 @@ variable "resources_to_tag" {
   default     = []
   validation {
     condition = (
-      length(compact([for r in var.resources_to_tag : r if !contains(["instance", "volume", "elastic-gpu", "spot-instances-request"], r)])) == 0
+      length(compact([for r in var.resources_to_tag : r if ! contains(["instance", "volume", "elastic-gpu", "spot-instances-request"], r)])) == 0
     )
     error_message = "Invalid resource type in `resources_to_tag`. Valid types are \"instance\", \"volume\", \"elastic-gpu\", \"spot-instances-request\"."
   }


### PR DESCRIPTION
## what

This PR adds a variable that allows users to declare additional principals that should be included in the assume role policy.

## why

Where I work the managed AWS accounts enforce that every role should be able be assumed by a "watchdog" role. If a role does not contain this trusted relationship, it will be added automatically and lead to Terraform drift.

## todo

If this PR is in principle acceptable I would require tips / help:

* Is the naming of the variable okay?
* How to update docs? Manually?
* Should I revert the `terraform fmt` changes?
