### PR TITLE
minimum required Terraform version bumped to 0.13.0, context.tf updated, readme updated

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -1,29 +1,29 @@
 
 locals {
-  // "amazon-eks-gpu-node-",
+  # "amazon-eks-gpu-node-",
   arch_label_map = {
     "AL2_x86_64" : "",
     "AL2_x86_64_GPU" : "-gpu",
     "AL2_ARM_64" : "-arm64",
   }
 
-  // Kubernetes version priority (first one to be set wins)
-  // 1. prefix of var.ami_release_version
-  // 2. var.kubernetes_version
-  // 3. data.eks_cluster.this.kubernetes_version
+  # Kubernetes version priority (first one to be set wins)
+  # 1. prefix of var.ami_release_version
+  # 2. var.kubernetes_version
+  # 3. data.eks_cluster.this.kubernetes_version
   need_cluster_kubernetes_version = local.enabled ? local.need_ami_id && length(compact([var.ami_release_version, var.kubernetes_version])) == 0 : false
 
   ami_kubernetes_version = local.need_ami_id ? (local.need_cluster_kubernetes_version ? data.aws_eks_cluster.this[0].version :
     regex("^(\\d+\\.\\d+)", coalesce(var.ami_release_version, var.kubernetes_version))[0]
   ) : ""
 
-  // Note: the expression:
-  //   length(compact([x])) > 0
-  // is a clean way to evaluate `x` and return false if x is null or an empty string.
-  // All string functions return an error when an argument is null, so the alternative
-  //   (x != null) && (x != "")
-  // length(compact([var.ami_release_version])) > 0
-  // (var.ami_release_version != null) && (var.ami_release_version != "")
+  # Note: the expression:
+  #   length(compact([x])) > 0
+  # is a clean way to evaluate `x` and return false if x is null or an empty string.
+  # All string functions return an error when an argument is null, so the alternative
+  #   (x != null) && (x != "")
+  # length(compact([var.ami_release_version])) > 0
+  # (var.ami_release_version != null) && (var.ami_release_version != "")
   ami_version_regex = local.need_ami_id ? (length(compact([var.ami_release_version])) > 0 ?
     replace(var.ami_release_version, "/^(\\d+\\.\\d+)\\.\\d+-(\\d+)$/", "$1-v$2") :
     "${local.ami_kubernetes_version}-*"

--- a/variables.tf
+++ b/variables.tf
@@ -202,7 +202,7 @@ variable "launch_template_disk_encryption_enabled" {
 
 variable "launch_template_name" {
   type = string
-  // Note: the aws_launch_template data source only accepts name, not ID, to specify the launch template, so we cannot support ID as input.
+  # Note: the aws_launch_template data source only accepts name, not ID, to specify the launch template, so we cannot support ID as input.
   description = "The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id."
   default     = null
 }


### PR DESCRIPTION
## what
- update context.tf to v0.23.0 
- minimum required Terraform version bumped to 0.13.0 
- readme updated, Bridgecrew compliance badges added

## why
- It allows for setting the letter case of tag names and labels
- we have dropped support for Terraform 0.12
- To be able see and fix the recommendations from Bridgecrew so we can position our modules as standards compliant
