### PR TITLE
feat(aws_launch_template): parametrize metadata_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Available targets:
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ Available targets:
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"required"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Available targets:
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | n/a | yes |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"required"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Available targets:
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | launch\_template\_disk\_encryption\_enabled | Enable disk encryption for the created launch template (if we aren't provided with an existing launch template) | `bool` | `false` | no |
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
+| launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
+| launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Available targets:
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | n/a | yes |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -285,12 +285,12 @@ Available targets:
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | launch\_template\_disk\_encryption\_enabled | Enable disk encryption for the created launch template (if we aren't provided with an existing launch template) | `bool` | `false` | no |
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
-| launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
-| launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |
+| metadata\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
+| metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| metadata\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | min\_size | Minimum number of worker nodes | `number` | n/a | yes |
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,6 +81,7 @@
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,7 +81,7 @@
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | n/a | yes |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,7 +81,6 @@
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"required"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -79,6 +79,9 @@
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | launch\_template\_disk\_encryption\_enabled | Enable disk encryption for the created launch template (if we aren't provided with an existing launch template) | `bool` | `false` | no |
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
+| launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
+| launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -79,12 +79,12 @@
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
 | launch\_template\_disk\_encryption\_enabled | Enable disk encryption for the created launch template (if we aren't provided with an existing launch template) | `bool` | `false` | no |
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
-| launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
-| launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |
+| metadata\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
+| metadata\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
+| metadata\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"optional"` | no |
 | min\_size | Minimum number of worker nodes | `number` | n/a | yes |
 | module\_depends\_on | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,7 +81,7 @@
 | launch\_template\_disk\_encryption\_kms\_key\_id | Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true | `string` | `""` | no |
 | launch\_template\_metadata\_options\_http\_endpoint | Whether the metadata service is available. Can be enabled or disabled | `string` | `"enabled"` | no |
 | launch\_template\_metadata\_options\_http\_put\_response\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64 | `number` | `2` | no |
-| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | n/a | yes |
+| launch\_template\_metadata\_options\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required | `string` | `"required"` | no |
 | launch\_template\_name | The name (not ID) of a custom launch template to use for the EKS node group. If provided, it must specify the AMI image id. | `string` | `null` | no |
 | launch\_template\_version | The version of the specified launch template to use. Defaults to latest version. | `string` | `null` | no |
 | max\_size | Maximum number of worker nodes | `number` | n/a | yes |

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -45,6 +45,7 @@ locals {
   # launch_template_key = join(":", coalescelist(local.launch_template_vpc_security_group_ids, ["closed"]))
 }
 
+
 resource "aws_launch_template" "default" {
   # We'll use this default if we aren't provided with a launch template during invocation
   # We need to generate a new launch template every time the security group list changes
@@ -90,10 +91,13 @@ resource "aws_launch_template" "default" {
   #     If any containers that you deploy to the node group use the Instance Metadata Service Version 2,
   #     then make sure to set the Metadata response hop limit to 2 in your launch template.
   metadata_options {
-    http_put_response_hop_limit = 2
+
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
-    http_endpoint = "enabled"
+
+    http_endpoint               = var.launch_template_metadata_options_http_endpoint
+    http_put_response_hop_limit = var.launch_template_metadata_options_http_put_response_hop_limit
+    http_tokens                 = var.launch_template_metadata_options_http_tokens
   }
 
   vpc_security_group_ids = local.launch_template_vpc_security_group_ids

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -97,7 +97,7 @@ resource "aws_launch_template" "default" {
 
     http_endpoint               = var.launch_template_metadata_options_http_endpoint
     http_put_response_hop_limit = var.launch_template_metadata_options_http_put_response_hop_limit
-    http_tokens                 = var.launch_template_metadata_options_http_tokens
+    http_tokens                 = "required"
   }
 
   vpc_security_group_ids = local.launch_template_vpc_security_group_ids

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -91,7 +91,6 @@ resource "aws_launch_template" "default" {
   #     If any containers that you deploy to the node group use the Instance Metadata Service Version 2,
   #     then make sure to set the Metadata response hop limit to 2 in your launch template.
   metadata_options {
-
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
 

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -93,9 +93,9 @@ resource "aws_launch_template" "default" {
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
 
-    http_endpoint               = var.metadata_options_http_endpoint
-    http_put_response_hop_limit = var.metadata_options_http_put_response_hop_limit
-    http_tokens                 = var.metadata_options_http_tokens
+    http_endpoint               = var.metadata_http_endpoint
+    http_put_response_hop_limit = var.metadata_http_put_response_hop_limit
+    http_tokens                 = var.metadata_http_tokens
   }
 
   vpc_security_group_ids = local.launch_template_vpc_security_group_ids

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -45,7 +45,6 @@ locals {
   # launch_template_key = join(":", coalescelist(local.launch_template_vpc_security_group_ids, ["closed"]))
 }
 
-
 resource "aws_launch_template" "default" {
   # We'll use this default if we aren't provided with a launch template during invocation
   # We need to generate a new launch template every time the security group list changes

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -93,9 +93,9 @@ resource "aws_launch_template" "default" {
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
 
-    http_endpoint               = var.launch_template_metadata_options_http_endpoint
-    http_put_response_hop_limit = var.launch_template_metadata_options_http_put_response_hop_limit
-    http_tokens                 = var.launch_template_metadata_options_http_tokens
+    http_endpoint               = var.metadata_options_http_endpoint
+    http_put_response_hop_limit = var.metadata_options_http_put_response_hop_limit
+    http_tokens                 = var.metadata_options_http_tokens
   }
 
   vpc_security_group_ids = local.launch_template_vpc_security_group_ids

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -95,7 +95,7 @@ resource "aws_launch_template" "default" {
 
     http_endpoint               = var.launch_template_metadata_options_http_endpoint
     http_put_response_hop_limit = var.launch_template_metadata_options_http_put_response_hop_limit
-    http_tokens                 = "required"
+    http_tokens                 = var.launch_template_metadata_options_http_tokens
   }
 
   vpc_security_group_ids = local.launch_template_vpc_security_group_ids

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   features_require_ami               = local.enabled && local.need_bootstrap
   configured_ami_image_id            = var.ami_image_id == null ? "" : var.ami_image_id
   need_ami_id                        = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
-  need_imds_settings = var.launch_template_metadata_options_http_endpoint != "enabled" || var.launch_template_metadata_options_http_put_response_hop_limit != 1 || var.launch_template_metadata_options_http_tokens != "optional"
+  need_imds_settings = var.metadata_http_endpoint != "enabled" || var.metadata_http_put_response_hop_limit != 1 || var.metadata_http_tokens != "optional"
   features_require_launch_template   = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.need_imds_settings : false
 
   have_ssh_key = var.ec2_ssh_key != null && var.ec2_ssh_key != ""

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,11 @@ locals {
   enabled = module.this.enabled
 
   # See https://aws.amazon.com/blogs/containers/introducing-launch-template-and-custom-ami-support-in-amazon-eks-managed-node-groups/
-  features_require_ami    = local.enabled && local.need_bootstrap
-  configured_ami_image_id = var.ami_image_id == null ? "" : var.ami_image_id
-  need_ami_id             = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
+  features_require_ami               = local.enabled && local.need_bootstrap
+  configured_ami_image_id            = var.ami_image_id == null ? "" : var.ami_image_id
+  need_ami_id                        = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
   features_require_imds_restrictions = var.launch_template_metadata_options_http_endpoint == "enabled" && var.launch_template_metadata_options_http_put_response_hop_limit == 1 && var.launch_template_metadata_options_http_tokens == "required"
-  features_require_launch_template = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.features_require_imds_restrictions : false
+  features_require_launch_template   = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.features_require_imds_restrictions : false
 
   have_ssh_key = var.ec2_ssh_key != null && var.ec2_ssh_key != ""
 

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
   features_require_ami               = local.enabled && local.need_bootstrap
   configured_ami_image_id            = var.ami_image_id == null ? "" : var.ami_image_id
   need_ami_id                        = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
-  features_require_imds_restrictions = var.launch_template_metadata_options_http_endpoint == "enabled" && var.launch_template_metadata_options_http_put_response_hop_limit == 1 && var.launch_template_metadata_options_http_tokens == "required"
-  features_require_launch_template   = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.features_require_imds_restrictions : false
+  need_imds_settings = var.launch_template_metadata_options_http_endpoint != "enabled" || var.launch_template_metadata_options_http_put_response_hop_limit != 1 || var.launch_template_metadata_options_http_tokens != "optional"
+  features_require_launch_template   = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.need_imds_settings : false
 
   have_ssh_key = var.ec2_ssh_key != null && var.ec2_ssh_key != ""
 

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
   features_require_ami    = local.enabled && local.need_bootstrap
   configured_ami_image_id = var.ami_image_id == null ? "" : var.ami_image_id
   need_ami_id             = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
-
-  features_require_launch_template = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami : false
+  features_require_imds_restrictions = var.launch_template_metadata_options_http_endpoint == "enabled" && var.launch_template_metadata_options_http_put_response_hop_limit == 1 && var.launch_template_metadata_options_http_tokens == "required"
+  features_require_launch_template = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.features_require_imds_restrictions : false
 
   have_ssh_key = var.ec2_ssh_key != null && var.ec2_ssh_key != ""
 

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,11 @@ locals {
   enabled = module.this.enabled
 
   # See https://aws.amazon.com/blogs/containers/introducing-launch-template-and-custom-ami-support-in-amazon-eks-managed-node-groups/
-  features_require_ami               = local.enabled && local.need_bootstrap
-  configured_ami_image_id            = var.ami_image_id == null ? "" : var.ami_image_id
-  need_ami_id                        = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
-  need_imds_settings = var.metadata_http_endpoint != "enabled" || var.metadata_http_put_response_hop_limit != 1 || var.metadata_http_tokens != "optional"
-  features_require_launch_template   = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.need_imds_settings : false
+  features_require_ami             = local.enabled && local.need_bootstrap
+  configured_ami_image_id          = var.ami_image_id == null ? "" : var.ami_image_id
+  need_ami_id                      = local.enabled ? local.features_require_ami && length(local.configured_ami_image_id) == 0 : false
+  need_imds_settings               = var.metadata_http_endpoint != "enabled" || var.metadata_http_put_response_hop_limit != 1 || var.metadata_http_tokens != "optional"
+  features_require_launch_template = local.enabled ? length(var.resources_to_tag) > 0 || local.need_userdata || local.features_require_ami || local.need_imds_settings : false
 
   have_ssh_key = var.ec2_ssh_key != null && var.ec2_ssh_key != ""
 

--- a/variables.tf
+++ b/variables.tf
@@ -290,9 +290,3 @@ variable "launch_template_metadata_options_http_endpoint" {
   type        = string
   description = " Whether the metadata service is available. Can be enabled or disabled"
 }
-
-variable "launch_template_metadata_options_http_tokens" {
-  default     = "required"
-  type        = string
-  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -279,19 +279,19 @@ variable "launch_template_disk_encryption_kms_key_id" {
   description = "Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true"
 }
 
-variable "launch_template_metadata_options_http_put_response_hop_limit" {
+variable "metadata_options_http_put_response_hop_limit" {
   default     = 2
   type        = number
   description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64"
 }
 
-variable "launch_template_metadata_options_http_endpoint" {
+variable "metadata_options_http_endpoint" {
   default     = "enabled"
   type        = string
   description = "Whether the metadata service is available. Can be enabled or disabled"
 }
 
-variable "launch_template_metadata_options_http_tokens" {
+variable "metadata_options_http_tokens" {
   default     = "optional"
   type        = string
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"

--- a/variables.tf
+++ b/variables.tf
@@ -292,7 +292,6 @@ variable "launch_template_metadata_options_http_endpoint" {
 }
 
 variable "launch_template_metadata_options_http_tokens" {
-  default     = "optional"
   type        = string
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -279,3 +279,20 @@ variable "launch_template_disk_encryption_kms_key_id" {
   description = "Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true"
 }
 
+variable "launch_template_metadata_options_http_put_response_hop_limit" {
+  default     = 2
+  type        = number
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64"
+}
+
+variable "launch_template_metadata_options_http_endpoint" {
+  default     = "enabled"
+  type        = string
+  description = " Whether the metadata service is available. Can be enabled or disabled"
+}
+
+variable "launch_template_metadata_options_http_tokens" {
+  default     = "optional"
+  type        = string
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -288,5 +288,11 @@ variable "launch_template_metadata_options_http_put_response_hop_limit" {
 variable "launch_template_metadata_options_http_endpoint" {
   default     = "enabled"
   type        = string
-  description = " Whether the metadata service is available. Can be enabled or disabled"
+  description = "Whether the metadata service is available. Can be enabled or disabled"
+}
+
+variable "launch_template_metadata_options_http_tokens" {
+  default     = "optional"
+  type        = string
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -292,6 +292,7 @@ variable "launch_template_metadata_options_http_endpoint" {
 }
 
 variable "launch_template_metadata_options_http_tokens" {
+  default     = "required"
   type        = string
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -279,19 +279,19 @@ variable "launch_template_disk_encryption_kms_key_id" {
   description = "Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true"
 }
 
-variable "metadata_options_http_put_response_hop_limit" {
+variable "metadata_http_put_response_hop_limit" {
   default     = 2
   type        = number
   description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from 1 to 64"
 }
 
-variable "metadata_options_http_endpoint" {
+variable "metadata_http_endpoint" {
   default     = "enabled"
   type        = string
   description = "Whether the metadata service is available. Can be enabled or disabled"
 }
 
-variable "metadata_options_http_tokens" {
+variable "metadata_http_tokens" {
   default     = "optional"
   type        = string
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required"


### PR DESCRIPTION
## what
* parametrized launch template metadata options 
* moved default values to variables.tf

## why
* Restricting access to the IMDS and Amazon EC2 instance profile credentials
* [EKS Security Best Practices](https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html)

## references
* closes #62 

