### PR TITLE
fix autoscaling taint labels syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
     for label, value in var.kubernetes_labels : format("k8s.io/cluster-autoscaler/node-template/label/%v", label) => value
   }
   autoscaler_kubernetes_taints_tags = {
-    for label, value in var.kubernetes_taints : format("k8s.io/cluster-autoscaler/node-template/taint/%v", label) => value
+    for taint in var.kubernetes_taints : format("k8s.io/cluster-autoscaler/node-template/taint/%v", taint.key) => taint.value
   }
   autoscaler_tags = merge(local.autoscaler_enabled_tags, local.autoscaler_kubernetes_label_tags, local.autoscaler_kubernetes_taints_tags)
 


### PR DESCRIPTION
## what
Use taints key and value as tags instead of array indices and object.

## why
Fixes the following error when trying to use both autoscaler and taints : 
```
Error: Incorrect attribute value type

  on .terraform/modules/eks_node_group/launch-template.tf line 105, in resource "aws_launch_template" "default":
 105:   tags                   = local.node_group_tags
    |----------------
    | local.node_group_tags is object with 7 attributes

Inappropriate value for attribute "tags": element
"k8s.io/cluster-autoscaler/node-template/taint/0": string required.
```

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #86`

