### PR TITLE
Allow enabled=false

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,7 +19,7 @@ locals {
   # The usage of the specific kubernetes.io/cluster/* resource tags below are required
   # for EKS and Kubernetes to discover and manage networking resources
   # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-  tags = merge(module.label.tags, map("kubernetes.io/cluster/${module.label.id}", "shared"))
+  tags = try(merge(module.label.tags, tomap("kubernetes.io/cluster/${module.label.id}", "shared")), null)
 
   # Unfortunately, most_recent (https://github.com/cloudposse/terraform-aws-eks-workers/blob/34a43c25624a6efb3ba5d2770a601d7cb3c0d391/main.tf#L141)
   # variable does not work as expected, if you are not going to use custom ami you should
@@ -135,7 +135,7 @@ module "eks_cluster" {
 module "eks_node_group" {
   source = "../../"
 
-  subnet_ids         = module.subnets.public_subnet_ids
+  subnet_ids         = module.this.enabled ? module.subnets.public_subnet_ids : ["filler_string_for_enabled_is_false"]
   cluster_name       = module.eks_cluster.eks_cluster_id
   instance_types     = var.instance_types
   desired_size       = var.desired_size

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ data "aws_eks_cluster" "this" {
 locals {
   ng = {
     cluster_name  = var.cluster_name
-    node_role_arn = local.create_role ? join("", aws_iam_role.default.*.arn) : var.node_role_arn[0]
+    node_role_arn = local.create_role ? join("", aws_iam_role.default.*.arn) : try(var.node_role_arn[0], null)
     # Keep sorted so that change in order does not trigger replacement via random_pet
     subnet_ids = sort(var.subnet_ids)
     # Always supply instance types via the node group, not the launch template,


### PR DESCRIPTION
## what
* Allow node group to be disabled

## why
* var.enabled should be respected by all resources

## references
* Closes https://github.com/cloudposse/terraform-aws-eks-node-group/issues/88

## local test

```
⨠ cd examples/complete
⨠ terraform plan -var-file=fixtures.us-east-2.tfvars


Changes to Outputs:
  + eks_node_group_resources = []
  + private_subnet_cidrs     = []
  + public_subnet_cidrs      = []

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

