### PR TITLE
Fix Elastic Kubernetes Service reference on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 -->
 
-Terraform module to provision an EKS Node Group for [Elastic Container Service for Kubernetes](https://aws.amazon.com/eks/).
+Terraform module to provision an EKS Node Group for [Elastic Kubernetes Service for Kubernetes](https://aws.amazon.com/eks/).
 
 Instantiate it multiple times to create many EKS node groups with specific settings such as GPUs, EC2 instance types, or autoscale parameters.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 -->
 
-Terraform module to provision an EKS Node Group for [Elastic Kubernetes Service for Kubernetes](https://aws.amazon.com/eks/).
+Terraform module to provision an EKS Node Group for [Elastic Container Service for Kubernetes](https://aws.amazon.com/eks/).
 
 Instantiate it multiple times to create many EKS node groups with specific settings such as GPUs, EC2 instance types, or autoscale parameters.
 
@@ -458,7 +458,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 


### PR DESCRIPTION
## what
- Fix the external link naming that is being used to reference for the official EKS documentation.

## why
- Even though the external link is correct, this could be misleading and cause confusion.

