### PR TITLE
Output launch template name

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Available targets:
 | <a name="output_eks_node_group_role_arn"></a> [eks\_node\_group\_role\_arn](#output\_eks\_node\_group\_role\_arn) | ARN of the worker nodes IAM role |
 | <a name="output_eks_node_group_role_name"></a> [eks\_node\_group\_role\_name](#output\_eks\_node\_group\_role\_name) | Name of the worker nodes IAM role |
 | <a name="output_eks_node_group_status"></a> [eks\_node\_group\_status](#output\_eks\_node\_group\_status) | Status of the EKS Node Group |
+| <a name="output_eks_worker_launch_template_name"></a> [eks\_worker\_launch\_template\_name](#output\_eks\_worker\_launch\_template\_name) | The launch template name provided or created for the worker nodes |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -116,4 +116,5 @@
 | <a name="output_eks_node_group_role_arn"></a> [eks\_node\_group\_role\_arn](#output\_eks\_node\_group\_role\_arn) | ARN of the worker nodes IAM role |
 | <a name="output_eks_node_group_role_name"></a> [eks\_node\_group\_role\_name](#output\_eks\_node\_group\_role\_name) | Name of the worker nodes IAM role |
 | <a name="output_eks_node_group_status"></a> [eks\_node\_group\_status](#output\_eks\_node\_group\_status) | Status of the EKS Node Group |
+| <a name="output_eks_worker_launch_template_name"></a> [eks\_worker\_launch\_template\_name](#output\_eks\_worker\_launch\_template\_name) | The launch template name provided or created for the worker nodes |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,5 +40,5 @@ output "eks_node_group_cbd_pet_name" {
 
 output "eks_worker_launch_template_name" {
   description = "The launch template name provided or created for the worker nodes"
-  value       = local.fetch_launch_template ? data.aws_launch_template.this.name : aws_launch_template.default.name
+  value       = local.enabled ? (local.fetch_launch_template ? data.aws_launch_template.this[0].name : aws_launch_template.default[0].name) : ""
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,6 @@ output "eks_node_group_cbd_pet_name" {
 }
 
 output "eks_worker_launch_template_name"
-  description = "The launch template name created for the worker nodes, if this module generated one"
-  value       = join("", aws_launch_template.*.name)
+  description = "The launch template name provided or created for the worker nodes"
+  value       = local.fetch_launch_template ? data.aws_launch_template.this.name : aws_launch_template.default.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,5 +40,5 @@ output "eks_node_group_cbd_pet_name" {
 
 output "eks_worker_launch_template_name" {
   description = "The launch template name provided or created for the worker nodes"
-  value       = local.enabled ? (local.fetch_launch_template ? data.aws_launch_template.this[0].name : aws_launch_template.default[0].name) : ""
+  value       = local.enabled ? (local.fetch_launch_template ? data.aws_launch_template.this[0].name : aws_launch_template.default[0].name) : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "eks_node_group_cbd_pet_name" {
   description = "The pet name of this node group, if this module generated one"
   value       = join("", random_pet.cbd.*.id)
 }
+
+output "eks_worker_launch_template_name"
+  description = "The launch template name created for the worker nodes, if this module generated one"
+  value       = join("", aws_launch_template.*.name)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,7 +38,7 @@ output "eks_node_group_cbd_pet_name" {
   value       = join("", random_pet.cbd.*.id)
 }
 
-output "eks_worker_launch_template_name"
+output "eks_worker_launch_template_name" {
   description = "The launch template name provided or created for the worker nodes"
   value       = local.fetch_launch_template ? data.aws_launch_template.this.name : aws_launch_template.default.name
 }


### PR DESCRIPTION
## what
Adds launch template name to outputs

## why
* This is useful for cases where a tool like `karpenter` is used to scale nodes and the same launch template should be used.

## references
* closes #102