### PR TITLE
Update pet name for new launch template version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,8 @@ resource "random_pet" "cbd" {
     ami_type       = local.ng.ami_type
     capacity_type  = local.ng.capacity_type
 
-    launch_template_id = local.launch_template_id
+    launch_template_id      = local.launch_template_id
+    launch_template_version = local.launch_template_version
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -96,12 +96,11 @@ resource "random_pet" "cbd" {
   length    = 1
 
   keepers = {
-    node_role_arn  = local.ng.node_role_arn
-    subnet_ids     = join(",", local.ng.subnet_ids)
-    instance_types = join(",", local.ng.instance_types)
-    ami_type       = local.ng.ami_type
-    capacity_type  = local.ng.capacity_type
-
+    node_role_arn           = local.ng.node_role_arn
+    subnet_ids              = join(",", local.ng.subnet_ids)
+    instance_types          = join(",", local.ng.instance_types)
+    ami_type                = local.ng.ami_type
+    capacity_type           = local.ng.capacity_type
     launch_template_id      = local.launch_template_id
     launch_template_version = local.launch_template_version
   }


### PR DESCRIPTION
## what
* Update pet name for new launch template version to force a new node group.

## why
* A new pet name and therefore node group needs to be created when the launch template version changes.

## references
* This is similar to #106 

