### PR TITLE
Add support for IPv6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -104,20 +104,20 @@ The table below correctly indicates which inputs are required.
 
 ### Major Changes (breaking and otherwise)
 
-With the v0.25.0 release of this module, it has undergone major breaking
-changes and added new features. Please see the [migration](MIGRATION.md)
+With the v2.0.0 (a.k.a. v0.25.0) release of this module, it has undergone major breaking
+changes and added new features. Please see the [migration](docs/migration-v1-v2.md)
 document for details.
 
 
 For a complete example, see [examples/complete](examples/complete).
 
-For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), 
+For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS),
 see [test](test).
 
 ### Terraform Version
 
 Terraform version 1.0 is out. Before that, there was Terraform version 0.15, 0.14, 0.13 and so on.
-The v0.25.0 release of this module drops support for Terraform 0.13. That version is old and has lots of known issues.
+The v2.0.0 release of this module drops support for Terraform 0.13. That version is old and has lots of known issues.
 There are hardly any breaking changes between Terraform 0.13 and 1.0, so please upgrade to
 the latest Terraform version before raising any issues about this module.
 
@@ -163,7 +163,7 @@ locals {
 module "vpc" {
   source = "cloudposse/vpc/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  # version = "x.x.x"
+  # version = "1.x.x"
 
   cidr_block = "172.16.0.0/16"
 
@@ -174,12 +174,12 @@ module "vpc" {
 module "subnets" {
   source = "cloudposse/dynamic-subnets/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  # version = "x.x.x"
+  # version = "2.x.x"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
 
@@ -190,7 +190,7 @@ module "subnets" {
 module "eks_cluster" {
   source = "cloudposse/eks-cluster/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  # version = "x.x.x"
+  # version = "2.x.x"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.subnets.public_subnet_ids
@@ -204,7 +204,7 @@ module "eks_cluster" {
 module "eks_node_group" {
   source = "cloudposse/eks-node-group/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  # version     = "x.x.x"
+  # version     = "2.x.x"
 
   instance_types        = [var.instance_type]
   subnet_ids            = module.subnets.public_subnet_ids
@@ -272,16 +272,18 @@ Available targets:
 |------|------|
 | [aws_eks_node_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
 | [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_iam_policy.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.amazon_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.amazon_eks_worker_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.existing_policies_for_eks_workers_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [random_pet.cbd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/launch_template) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 

--- a/README.yaml
+++ b/README.yaml
@@ -68,20 +68,20 @@ usage: |2-
 
   ### Major Changes (breaking and otherwise)
 
-  With the v0.25.0 release of this module, it has undergone major breaking
-  changes and added new features. Please see the [migration](MIGRATION.md)
+  With the v2.0.0 (a.k.a. v0.25.0) release of this module, it has undergone major breaking
+  changes and added new features. Please see the [migration](docs/migration-v1-v2.md)
   document for details.
 
 
   For a complete example, see [examples/complete](examples/complete).
 
-  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), 
+  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS),
   see [test](test).
 
   ### Terraform Version
 
   Terraform version 1.0 is out. Before that, there was Terraform version 0.15, 0.14, 0.13 and so on.
-  The v0.25.0 release of this module drops support for Terraform 0.13. That version is old and has lots of known issues.
+  The v2.0.0 release of this module drops support for Terraform 0.13. That version is old and has lots of known issues.
   There are hardly any breaking changes between Terraform 0.13 and 1.0, so please upgrade to
   the latest Terraform version before raising any issues about this module.
 
@@ -127,7 +127,7 @@ usage: |2-
   module "vpc" {
     source = "cloudposse/vpc/aws"
     # Cloud Posse recommends pinning every module to a specific version
-    # version = "x.x.x"
+    # version = "1.x.x"
 
     cidr_block = "172.16.0.0/16"
 
@@ -138,12 +138,12 @@ usage: |2-
   module "subnets" {
     source = "cloudposse/dynamic-subnets/aws"
     # Cloud Posse recommends pinning every module to a specific version
-    # version = "x.x.x"
+    # version = "2.x.x"
 
     availability_zones   = var.availability_zones
     vpc_id               = module.vpc.vpc_id
-    igw_id               = module.vpc.igw_id
-    cidr_block           = module.vpc.vpc_cidr_block
+    igw_id               = [module.vpc.igw_id]
+    ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
     nat_gateway_enabled  = true
     nat_instance_enabled = false
 
@@ -154,7 +154,7 @@ usage: |2-
   module "eks_cluster" {
     source = "cloudposse/eks-cluster/aws"
     # Cloud Posse recommends pinning every module to a specific version
-    # version = "x.x.x"
+    # version = "2.x.x"
 
     vpc_id     = module.vpc.vpc_id
     subnet_ids = module.subnets.public_subnet_ids
@@ -168,7 +168,7 @@ usage: |2-
   module "eks_node_group" {
     source = "cloudposse/eks-node-group/aws"
     # Cloud Posse recommends pinning every module to a specific version
-    # version     = "x.x.x"
+    # version     = "2.x.x"
 
     instance_types        = [var.instance_type]
     subnet_ids            = module.subnets.public_subnet_ids

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,16 +28,18 @@
 |------|------|
 | [aws_eks_node_group.cbd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
 | [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_iam_policy.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.amazon_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.amazon_eks_worker_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.existing_policies_for_eks_workers_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [random_pet.cbd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/launch_template) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/iam.tf
+++ b/iam.tf
@@ -36,12 +36,6 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
   role       = join("", aws_iam_role.default.*.name)
 }
 
-resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = local.create_role && var.node_role_cni_policy_enabled ? 1 : 0
-  policy_arn = format("%s/%s", local.aws_policy_prefix, "AmazonEKS_CNI_Policy")
-  role       = join("", aws_iam_role.default.*.name)
-}
-
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
   count      = local.create_role ? 1 : 0
   policy_arn = format("%s/%s", local.aws_policy_prefix, "AmazonEC2ContainerRegistryReadOnly")
@@ -53,3 +47,54 @@ resource "aws_iam_role_policy_attachment" "existing_policies_for_eks_workers_rol
   policy_arn = local.node_role_policy_arns[count.index]
   role       = join("", aws_iam_role.default.*.name)
 }
+
+# Create a CNI policy that is a merger of AmazonEKS_CNI_Policy and required IPv6 permissions
+# https://github.com/SummitRoute/aws_managed_policies/blob/master/policies/AmazonEKS_CNI_Policy
+# https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy
+
+data "aws_iam_policy_document" "ipv6_eks_cni_policy" {
+  count = local.create_role && var.node_role_cni_policy_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AssignIpv6Addresses",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:AttachNetworkInterface",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeTags",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DetachNetworkInterface",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:UnassignPrivateIpAddresses"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags"
+    ]
+    resources = [
+      "arn:${join("", data.aws_partition.current.*.partition)}:ec2:*:*:network-interface/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ipv6_eks_cni_policy" {
+  count = local.create_role && var.node_role_cni_policy_enabled ? 1 : 0
+
+  name   = "${module.this.id}-CNI_Policy"
+  policy = join("", data.aws_iam_policy_document.ipv6_eks_cni_policy.*.json)
+}
+
+resource "aws_iam_role_policy_attachment" "ipv6_eks_cni_policy" {
+  count = local.create_role && var.node_role_cni_policy_enabled ? 1 : 0
+
+  policy_arn = join("", aws_iam_policy.ipv6_eks_cni_policy.*.arn)
+  role       = join("", aws_iam_role.default.*.name)
+}
+

--- a/main.tf
+++ b/main.tf
@@ -178,7 +178,7 @@ resource "aws_eks_node_group" "default" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_worker_node_policy,
-    aws_iam_role_policy_attachment.amazon_eks_cni_policy,
+    aws_iam_role_policy_attachment.ipv6_eks_cni_policy,
     aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only,
     aws_iam_role_policy_attachment.existing_policies_for_eks_workers_role,
     aws_launch_template.default,
@@ -257,7 +257,7 @@ resource "aws_eks_node_group" "cbd" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_worker_node_policy,
-    aws_iam_role_policy_attachment.amazon_eks_cni_policy,
+    aws_iam_role_policy_attachment.ipv6_eks_cni_policy,
     aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only,
     aws_launch_template.default,
     module.ssh_access,


### PR DESCRIPTION
## what

- Update node group IAM role permissions to support IPv6

## why

- Previous permissions, using AWS managed policy `AmazonEKS_CNI_Policy`, are insufficient to enable proper functioning of the node when using IPv6

## notes

Upgrading to this version, if you have `node_role_cni_policy_enabled` set to `true` (the default), will cause a new IAM policy to be created and your existing node group IAM role to have its permissions updated. This will cause a transient interruption in the ability of the node to manage its network interface, but it should heal itself with no interruption to existing services. It may cause a short (some seconds) delay in being able to deploy new Pods. 

## references

- [Documentation](https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy) of recommended IPv6 permissions
- Third-party [documentation](https://github.com/SummitRoute/aws_managed_policies/blob/master/policies/AmazonEKS_CNI_Policy) of `AmazonEKS_CNI_Policy`.


