### PR TITLE
Windows node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ Available targets:
 ```
 <!-- markdownlint-restore -->
 <!-- markdownlint-disable -->
+## Windows Managed Node groups
+  Windows managed node-groups have a few pre-requisites.
+
+  * Your cluster must contain at least one linux based worker node
+  * Your EKS Cluster must have the `AmazonEKSVPCResourceController` and `AmazonEKSClusterPolicy` policies attached
+  * Your cluster must have a config-map called amazon-vpc-cni with the following content
+  ```yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  data:
+  enable-windows-ipam: "true"
+  ```
+  * It's advisable to taint your windows nodes
+  * Any pods that target windows will need to have the have the following attributes set in their manifest
+  ```yaml
+    nodeSelector:
+      kubernetes.io/os: windows
+      kubernetes.io/arch: amd64
+  ```
+
+https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -255,8 +280,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -295,7 +320,7 @@ Available targets:
 | <a name="input_after_cluster_joining_userdata"></a> [after\_cluster\_joining\_userdata](#input\_after\_cluster\_joining\_userdata) | Additional `bash` commands to execute on each worker node after joining the EKS cluster (after executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production | `list(string)` | `[]` | no |
 | <a name="input_ami_image_id"></a> [ami\_image\_id](#input\_ami\_image\_id) | AMI to use. Ignored if `launch_template_id` is supplied. | `list(string)` | `[]` | no |
 | <a name="input_ami_release_version"></a> [ami\_release\_version](#input\_ami\_release\_version) | EKS AMI version to use, e.g. For AL2 "1.16.13-20200821" or for bottlerocket "1.2.0-ccf1b754" (no "v"). For AL2 and bottlerocket, it defaults to latest version for Kubernetes version. | `list(string)` | `[]` | no |
-| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group.<br>Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`, `BOTTLEROCKET_x86_64`, and `BOTTLEROCKET_ARM_64`. | `string` | `"AL2_x86_64"` | no |
+| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group.<br>Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64,CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64, BOTTLEROCKET_ARM_64_NVIDIA, BOTTLEROCKET_x86_64_NVIDIA, WINDOWS_CORE_2019_x86_64, WINDOWS_FULL_2019_x86_64, WINDOWS_CORE_2022_x86_64, WINDOWS_FULL_2022_x86_64`. | `string` | `"AL2_x86_64"` | no |
 | <a name="input_associated_security_group_ids"></a> [associated\_security\_group\_ids](#input\_associated\_security\_group\_ids) | A list of IDs of Security Groups to associate the node group with, in addition to the EKS' created security group.<br>These security groups will not be modified. | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_before_cluster_joining_userdata"></a> [before\_cluster\_joining\_userdata](#input\_before\_cluster\_joining\_userdata) | Additional `bash` commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production | `list(string)` | `[]` | no |
@@ -465,7 +490,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -191,6 +191,7 @@ usage: |2-
 
 include:
   - "docs/targets.md"
+  - "docs/windows.md"
   - "docs/terraform.md"
 
 # Contributors to this project

--- a/ami.tf
+++ b/ami.tf
@@ -8,7 +8,7 @@ locals {
     "BOTTLEROCKET_x86_64" : "x86_64",
     "BOTTLEROCKET_ARM_64" : "aarch64"
     "BOTTLEROCKET_ARM_64_NVIDIA" : "-gpu"
-    "BOTTLEROCKET_x86_64_NVIDIA " : "-gpu"
+    "BOTTLEROCKET_x86_64_NVIDIA" : "-gpu"
     "WINDOWS_CORE_2019_x86_64" : ""
     "WINDOWS_FULL_2019_x86_64" : ""
     "WINDOWS_CORE_2022_x86_64" : ""

--- a/ami.tf
+++ b/ami.tf
@@ -7,6 +7,12 @@ locals {
     "AL2_ARM_64" : "-arm64",
     "BOTTLEROCKET_x86_64" : "x86_64",
     "BOTTLEROCKET_ARM_64" : "aarch64"
+    "BOTTLEROCKET_ARM_64_NVIDIA" : "-gpu"
+    "BOTTLEROCKET_x86_64_NVIDIA " : "-gpu"
+    "WINDOWS_CORE_2019_x86_64" : ""
+    "WINDOWS_FULL_2019_x86_64" : ""
+    "WINDOWS_CORE_2022_x86_64" : ""
+    "WINDOWS_FULL_2022_x86_64" : ""
   }
 
   ami_kind = split("_", var.ami_type)[0]
@@ -18,6 +24,12 @@ locals {
     # bottlerocket-aws-k8s-{ami_kubernetes_version}-{arch_label}-v{ami_version}
     # e.g. bottlerocket-aws-k8s-1.21-x86_64-v1.2.0-ccf1b754
     "BOTTLEROCKET" : "bottlerocket-aws-k8s-%s-%s-%s"
+    # Windows_Server-2019-English-Core-EKS_Optimized-{ami_kubernetes_version}-{ami_version}
+    # e.g. Windows_Server-2019-English-Core-EKS_Optimized-1.23-2022.11.08
+    "WINDOWS_CORE_2019" : "Windows_Server-2019-English-Core-EKS_Optimized-%s-%s"
+    "WINDOWS_FULL_2019" : "Windows_Server-2019-English-Full-EKS_Optimized-%s-%s"
+    "WINDOWS_CORE_2022" : "Windows_Server-2022-English-Core-EKS_Optimized-%s-%s"
+    "WINDOWS_FULL_2022" : "Windows_Server-2022-English-Full-EKS_Optimized-%s-%s"
   }
 
   # Kubernetes version priority (first one to be set wins)
@@ -37,19 +49,25 @@ locals {
     # if ami_release_version = "1.21-20211013"
     #   insert the letter v prior to the ami_version so it becomes 1.21-v20211013
     # if not, use the kubernetes version
-    "AL2" : (length(var.ami_release_version) == 1 ?
-      replace(var.ami_release_version[0], "/^(\\d+\\.\\d+)\\.\\d+-(\\d+)$/", "$1-v$2") :
+    "AL2" : (length(var.ami_release_version) == 1 ? replace(var.ami_release_version[0], "/^(\\d+\\.\\d+)\\.\\d+-(\\d+)$/", "$1-v$2") :
     "${local.ami_kubernetes_version}-*"),
     # if ami_release_version = "1.2.0-ccf1b754"
     #   prefex the ami release version with the letter v
     # if not, use an asterisk
-    "BOTTLEROCKET" : (length(var.ami_release_version) == 1 ?
-    format("v%s", var.ami_release_version[0]) : "*"),
+    "BOTTLEROCKET" : (length(var.ami_release_version) == 1 ? format("v%s", var.ami_release_version[0]) : "*"),
+    "WINDOWS_CORE_2019" : (length(var.ami_release_version) == 1 ? format("%s", var.ami_release_version[0]) : "*"),
+    "WINDOWS_FULL_2019" : (length(var.ami_release_version) == 1 ? format("%s", var.ami_release_version[0]) : "*"),
+    "WINDOWS_CORE_2022" : (length(var.ami_release_version) == 1 ? format("%s", var.ami_release_version[0]) : "*"),
+    "WINDOWS_FULL_2022" : (length(var.ami_release_version) == 1 ? format("%s", var.ami_release_version[0]) : "*"),
   } : {}
 
   ami_regex = local.need_ami_id ? {
     "AL2" : format(local.ami_format["AL2"], local.arch_label_map[var.ami_type], local.ami_version_regex[local.ami_kind]),
     "BOTTLEROCKET" : format(local.ami_format["BOTTLEROCKET"], local.ami_kubernetes_version, local.arch_label_map[var.ami_type], local.ami_version_regex[local.ami_kind]),
+    "WINDOWS_CORE_2019" : format(local.ami_format["WINDOWS_CORE_2019"], local.ami_kubernetes_version, local.ami_version_regex[local.ami_kind]),
+    "WINDOWS_FULL_2019" : format(local.ami_format["WINDOWS_FULL_2019"], local.ami_kubernetes_version, local.ami_version_regex[local.ami_kind]),
+    "WINDOWS_CORE_2022" : format(local.ami_format["WINDOWS_CORE_2022"], local.ami_kubernetes_version, local.ami_version_regex[local.ami_kind]),
+    "WINDOWS_FULL_2022" : format(local.ami_format["WINDOWS_FULL_2022"], local.ami_kubernetes_version, local.ami_version_regex[local.ami_kind]),
   } : {}
 }
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,8 +11,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -51,7 +51,7 @@
 | <a name="input_after_cluster_joining_userdata"></a> [after\_cluster\_joining\_userdata](#input\_after\_cluster\_joining\_userdata) | Additional `bash` commands to execute on each worker node after joining the EKS cluster (after executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production | `list(string)` | `[]` | no |
 | <a name="input_ami_image_id"></a> [ami\_image\_id](#input\_ami\_image\_id) | AMI to use. Ignored if `launch_template_id` is supplied. | `list(string)` | `[]` | no |
 | <a name="input_ami_release_version"></a> [ami\_release\_version](#input\_ami\_release\_version) | EKS AMI version to use, e.g. For AL2 "1.16.13-20200821" or for bottlerocket "1.2.0-ccf1b754" (no "v"). For AL2 and bottlerocket, it defaults to latest version for Kubernetes version. | `list(string)` | `[]` | no |
-| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group.<br>Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`, `BOTTLEROCKET_x86_64`, and `BOTTLEROCKET_ARM_64`. | `string` | `"AL2_x86_64"` | no |
+| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group.<br>Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64,CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64, BOTTLEROCKET_ARM_64_NVIDIA, BOTTLEROCKET_x86_64_NVIDIA, WINDOWS_CORE_2019_x86_64, WINDOWS_FULL_2019_x86_64, WINDOWS_CORE_2022_x86_64, WINDOWS_FULL_2022_x86_64`. | `string` | `"AL2_x86_64"` | no |
 | <a name="input_associated_security_group_ids"></a> [associated\_security\_group\_ids](#input\_associated\_security\_group\_ids) | A list of IDs of Security Groups to associate the node group with, in addition to the EKS' created security group.<br>These security groups will not be modified. | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_before_cluster_joining_userdata"></a> [before\_cluster\_joining\_userdata](#input\_before\_cluster\_joining\_userdata) | Additional `bash` commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For more info, see https://kubedex.com/90-days-of-aws-eks-in-production | `list(string)` | `[]` | no |

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,25 @@
+<!-- markdownlint-disable -->
+## Windows Managed Node groups
+  Windows managed node-groups have a few pre-requisites.
+
+  * Your cluster must contain at least one linux based worker node
+  * Your EKS Cluster must have the `AmazonEKSVPCResourceController` and `AmazonEKSClusterPolicy` policies attached
+  * Your cluster must have a config-map called amazon-vpc-cni with the following content
+  ```yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  data:
+  enable-windows-ipam: "true"
+  ```
+  * It's advisable to taint your windows nodes
+  * Any pods that target windows will need to have the have the following attributes set in their manifest
+  ```yaml
+    nodeSelector:
+      kubernetes.io/os: windows
+      kubernetes.io/arch: amd64
+  ```
+
+https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,7 +14,14 @@
   data:
   enable-windows-ipam: "true"
   ```
-  * It's advisable to taint your windows nodes
+  * It's advisable to taint your Windows nodes
+  ```yaml
+  kubernetes_taints = [{
+    key    = "WINDOWS"
+    value  = "true"
+    effect = "NO_SCHEDULE"
+  }]
+  ```
   * Any pods that target windows will need to have the have the following attributes set in their manifest
   ```yaml
     nodeSelector:

--- a/iam.tf
+++ b/iam.tf
@@ -51,9 +51,9 @@ resource "aws_iam_role_policy_attachment" "existing_policies_for_eks_workers_rol
 # Create a CNI policy that is a merger of AmazonEKS_CNI_Policy and required IPv6 permissions
 # https://github.com/SummitRoute/aws_managed_policies/blob/master/policies/AmazonEKS_CNI_Policy
 # https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy
-
+# https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
 data "aws_iam_policy_document" "ipv6_eks_cni_policy" {
-  count = local.create_role && var.node_role_cni_policy_enabled ? 1 : 0
+  count = local.create_role && var.node_role_cni_policy_enabled || local.create_role && can(regex("WINDOWS", var.ami_type)) ? 1 : 0
 
   statement {
     effect = "Allow"

--- a/userdata.tf
+++ b/userdata.tf
@@ -41,7 +41,7 @@ locals {
   (length(var.before_cluster_joining_userdata) > 0) || local.need_bootstrap) : false
 
   userdata = local.need_userdata ? (
-    base64encode(templatefile("${path.module}/userdata.tpl", merge(local.userdata_vars, local.cluster_data)))) : (
+    base64encode(templatefile(can(regex("WINDOWS", var.ami_type)) ? "${path.module}/userdata_nt.tpl" : "${path.module}/userdata.tpl", merge(local.userdata_vars, local.cluster_data)))) : (
     try(var.userdata_override_base64[0], null)
   )
 }

--- a/userdata_nt.tpl
+++ b/userdata_nt.tpl
@@ -1,0 +1,10 @@
+<powershell>
+[string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
+
+${before_cluster_joining_userdata}
+
+& $EKSBootstrapScriptFile -EKSClusterName "${cluster_name}" -APIServerEndpoint "${cluster_endpoint}" -Base64ClusterCA "${certificate_authority_data}" -KubeletExtraArgs "${bootstrap_extra_args}" 3>&1 4>&1 5>&1 6>&1
+$LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
+
+${after_cluster_joining_userdata}
+</powershell>

--- a/variables.tf
+++ b/variables.tf
@@ -111,14 +111,14 @@ variable "ami_type" {
   type        = string
   description = <<-EOT
     Type of Amazon Machine Image (AMI) associated with the EKS Node Group.
-    Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`, `BOTTLEROCKET_x86_64`, and `BOTTLEROCKET_ARM_64`.
+    Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64,CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64, BOTTLEROCKET_ARM_64_NVIDIA, BOTTLEROCKET_x86_64_NVIDIA, WINDOWS_CORE_2019_x86_64, WINDOWS_FULL_2019_x86_64, WINDOWS_CORE_2022_x86_64, WINDOWS_FULL_2022_x86_64`.
     EOT
   default     = "AL2_x86_64"
   validation {
     condition = (
-      contains(["AL2_x86_64", "AL2_x86_64_GPU", "AL2_ARM_64", "BOTTLEROCKET_x86_64", "BOTTLEROCKET_ARM_64", "CUSTOM"], var.ami_type)
+      contains(["AL2_x86_64", "AL2_x86_64_GPU", "AL2_ARM_64", "CUSTOM", "BOTTLEROCKET_ARM_64", "BOTTLEROCKET_x86_64", "BOTTLEROCKET_ARM_64_NVIDIA", "BOTTLEROCKET_x86_64_NVIDIA", "WINDOWS_CORE_2019_x86_64", "WINDOWS_FULL_2019_x86_64", "WINDOWS_CORE_2022_x86_64", "WINDOWS_FULL_2022_x86_64"], var.ami_type)
     )
-    error_message = "Var ami_type must be one of \"AL2_x86_64\", \"AL2_x86_64_GPU\", \"AL2_ARM_64\", \"BOTTLEROCKET_x86_64\", \"BOTTLEROCKET_ARM_64\", or \"CUSTOM\"."
+    error_message = "Var ami_type must be one of \"AL2_x86_64\",\"AL2_x86_64_GPU\",\"AL2_ARM_64\",\"BOTTLEROCKET_ARM_64\",\"BOTTLEROCKET_x86_64\",\"BOTTLEROCKET_ARM_64_NVIDIA\",\"BOTTLEROCKET_x86_64_NVIDIA\",\"WINDOWS_CORE_2019_x86_64\",\"WINDOWS_FULL_2019_x86_64\",\"WINDOWS_CORE_2022_x86_64\",\"WINDOWS_FULL_2022_x86_64\", or \"CUSTOM\"."
   }
 }
 


### PR DESCRIPTION
## what
* Adds support for 2019/2022 (windows lts) ami-types as per the aws sdk docs
* Docs to support usage and link to ref docs https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html

## why
* Windows EKS Managed node support https://github.com/aws/containers-roadmap/issues/584

## references
* https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
* https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-versions-windows.html

## Tested 
![image](https://user-images.githubusercontent.com/83597/210409914-789aa758-3d14-4e27-abdc-7694ec17cdb7.png)
![image](https://user-images.githubusercontent.com/83597/210410260-3d8c1026-9433-4cdc-8740-76647d99c37c.png)
![image](https://user-images.githubusercontent.com/83597/210410355-25bc1d24-d2cc-49eb-ab80-37fdb7ac9cfd.png)
![image](https://user-images.githubusercontent.com/83597/210410831-846a8fdd-2e5a-4a05-9308-70f04b5f1897.png)

```hcl
module "eks_windows_node_group" {
  # source  = "cloudposse/eks-node-group/aws"
  # version = "2.6.1"
  source = "github.com/ChrisMcKee/terraform-aws-eks-node-group"

  instance_types     = ["t3.large", "t3a.large", "c5.large", "c6i.large", "m6i.large", "r6i.large"]
  subnet_ids         = [data.terraform_remote_state.network.outputs.private_subnets[1]]
  min_size           = 1
  max_size           = 1
  desired_size       = 1
  cluster_name       = module.eks_cluster.eks_cluster_id
  kubernetes_version = var.kubernetes_version == null || var.kubernetes_version == "" ? [] : [var.kubernetes_version]
  kubernetes_labels  = var.labels

  ami_type = "WINDOWS_CORE_2019_x86_64"

  update_config = [{ max_unavailable = 1 }]

  capacity_type = "SPOT"

  kubernetes_taints = [{
    key    = "WINDOWS"
    value  = "true"
    effect = "NO_SCHEDULE"
  }]

  node_role_arn                = [aws_iam_role.worker_role_nt.arn]
  node_role_cni_policy_enabled = false #We use the Service Account as per best practice

  associated_security_group_ids = [data.terraform_remote_state.network.outputs.ops_ssh, aws_security_group.workers.id]

  # Enable the Kubernetes cluster auto-scaler to find the auto-scaling group
  cluster_autoscaler_enabled = true

  context = module.windowslabel.context

  # Ensure the cluster is fully created before trying to add the node group
  module_depends_on = [module.eks_cluster.kubernetes_config_map_id]

  # Ensure ordering of resource creation to eliminate the race conditions when applying the Kubernetes Auth ConfigMap.
  # Do not create Node Group before the EKS cluster is created and the `aws-auth` Kubernetes ConfigMap is applied.
  depends_on = [module.eks_cluster, module.eks_cluster.kubernetes_config_map_id]

  create_before_destroy = true

  node_role_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]

  block_device_mappings = [
    {
      "delete_on_termination" : true,
      "device_name" : "/dev/xvda",
      "encrypted" : true,
      "volume_size" : 80,
      "volume_type" : "gp3"
    }
  ]

  node_group_terraform_timeouts = [{
    create = "40m"
    update = null
    delete = "20m"
  }]

  #Valid types are "instance", "volume", "elastic-gpu", "spot-instances-request", "network-interface".
  resources_to_tag = ["instance", "volume", "spot-instances-request", "network-interface"]
}
```
