### PR TITLE
fix: variable description for var.bootstrap_additional_options

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -337,7 +337,7 @@ variable "after_cluster_joining_userdata" {
 variable "bootstrap_additional_options" {
   type        = list(string)
   default     = []
-  description = "Additional options to bootstrap.sh. DO NOT include `--kubelet-additional-args`, use `kubelet_additional_args` var instead."
+  description = "Additional options to bootstrap.sh. DO NOT include `--kubelet-additional-args`, use `kubelet_additional_options` var instead."
   validation {
     condition = (
       length(var.bootstrap_additional_options) < 2


### PR DESCRIPTION
## what

- Fixing variable description as it references another variable that doesn't exist.

## why

Should save someone time in the future when they try and find the variable as mentioned in the description.

