### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/ami.tf
+++ b/ami.tf
@@ -22,7 +22,7 @@ locals {
     # e.g. amazon-eks-arm64-node-1.21-v20211013
     AL2 = "amazon-eks%s-node-%s"
     # bottlerocket-aws-k8s-{ami_kubernetes_version}-{arch_label}-v{ami_version}
-    # e.g. bottlerocket-aws-k8s-1.21-x86_64-v1.2.0-ccf1b754
+    # e.g. bottlerocket-aws-k8s-1.21-x86_64-v1[2].0-ccf1b754
     BOTTLEROCKET = "bottlerocket-aws-k8s-%s-%s-%s"
     # Windows_Server-2019-English-Core-EKS_Optimized-{ami_kubernetes_version}-{ami_version}
     # e.g. Windows_Server-2019-English-Core-EKS_Optimized-1.23-2022.11.08

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -48,29 +48,22 @@ locals {
 }
 
 module "vpc" {
-  source  = "cloudposse/vpc/aws"
-  version = "1.1.0"
-
-  cidr_block = var.vpc_cidr_block
-  tags       = local.tags
-
-  context = module.this.context
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
+  context                 = module.this.context
 }
 
 module "subnets" {
-  source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.0.2"
-
+  source               = "cloudposse/dynamic-subnets/aws"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = [module.vpc.igw_id]
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
-  max_nats             = 1
-  nat_gateway_enabled  = true
+  nat_gateway_enabled  = false
   nat_instance_enabled = false
-  tags                 = local.tags
-
-  context = module.this.context
+  context              = module.this.context
 }
 
 module "ssh_source_access" {


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
