### PR TITLE
Remove ssh-egress security group rule

### DIFF
--- a/security-group.tf
+++ b/security-group.tf
@@ -27,14 +27,6 @@ module "ssh_access" {
       from_port   = 22
       to_port     = 22
       description = "Allow SSH ingress"
-      },
-      {
-        key         = "ssh-egress"
-        type        = "egress"
-        from_port   = 0
-        to_port     = 65535
-        protocol    = "tcp"
-        description = "Allow SSH egress"
     }]
   }]
 


### PR DESCRIPTION
## what

* Delete the unnecessary "ssh-egress" security-group rule.  It does not provide anything related to SSH.

⚠️  This might break environments for people who are accidentally relying on the wide security group rules for non-ssh outbound access.  However it will allow others to be more secure and tighten down their security posture.

## why

AWS Security Groups are stateful, meaning that any inbound traffic that is allowed will automatically permit the return outbound traffic, regardless of outbound rules.  Security Groups track TCP connections in order to determine which packets are responses to allowed inbound traffic.

When you establish an SSH connection, you're initiating an inbound connection to the server. The server's response to your connection, as well as any subsequent communication, is considered outbound traffic from the perspective of the security group.

Because of the stateful nature of AWS Security Groups, once you've allowed inbound SSH traffic, the return traffic (outbound from the server) is automatically allowed, even if your outbound rules don't explicitly permit it.

Therefore, an outbound rule that allows traffic on all ports is not necessary for the operation of inbound SSH.

## references

* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html
