### PR TITLE
Made necessary changes for worker node AL2023 in version 1.0.1

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -5,6 +5,7 @@ locals {
     "AL2_x86_64" : "",
     "AL2_x86_64_GPU" : "-gpu",
     "AL2_ARM_64" : "-arm64",
+    "AL2023_x86_64_standard" : "x86_64"
   }
 
   # Kubernetes version priority (first one to be set wins)
@@ -29,7 +30,7 @@ locals {
     "${local.ami_kubernetes_version}-*"
   ) : ""
 
-  ami_regex = local.need_ami_id ? format("amazon-eks%s-node-%s", local.arch_label_map[var.ami_type], local.ami_version_regex) : ""
+  ami_regex = local.need_ami_id ? format("amazon-eks-node-al2023-%s-standard-%s", local.arch_label_map[var.ami_type], local.ami_version_regex) : ""
 }
 
 data "aws_ami" "selected" {

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -1,22 +1,28 @@
 MIME-Version: 1.0
-Content-Type: multipart/mixed; boundary="/:/+++"
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
 
---/:/+++
+--==MYBOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
+
 #!/bin/bash
+set -ex
 
 # In multipart MIME format to support EKS appending to it
 
-${before_cluster_joining_userdata}
+/etc/eks/bootstrap.sh ipv4-prefix-delegation  --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' --container-runtime containerd  --dns-cluster-ip 172.20.0.10 
 
-%{ if length(kubelet_extra_args) > 0 }
-export KUBELET_EXTRA_ARGS="${kubelet_extra_args}"
-%{ endif }
-%{ if length(kubelet_extra_args) > 0 || length (bootstrap_extra_args) > 0 || length (after_cluster_joining_userdata) > 0 }
 
-/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'
+--==MYBOUNDARY==
+Content-Type: application/node.eks.aws
 
-${after_cluster_joining_userdata}
-%{ endif }
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: ${cluster_name}
+    apiServerEndpoint: ${cluster_endpoint}
+    certificateAuthority: ${certificate_authority_data}
+    cidr: 10.190.0.0/19
 
---/:/+++--
+--==MYBOUNDARY==--    

--- a/variables.tf
+++ b/variables.tf
@@ -82,14 +82,14 @@ variable "ami_type" {
   type        = string
   description = <<-EOT
     Type of Amazon Machine Image (AMI) associated with the EKS Node Group.
-    Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, and `AL2_ARM_64`.
+    Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64` and `AL2023_x86_64_standard`.
     EOT
-  default     = "AL2_x86_64"
+  default     = "AL2023_x86_64_standard"
   validation {
     condition = (
-      contains(["AL2_x86_64", "AL2_x86_64_GPU", "AL2_ARM_64"], var.ami_type)
+      contains(["AL2_x86_64", "AL2_x86_64_GPU", "AL2_ARM_64", "AL2023_x86_64_standard"], var.ami_type)
     )
-    error_message = "Var ami_type must be one of \"AL2_x86_64\", \"AL2_x86_64_GPU\", and \"AL2_ARM_64\"."
+    error_message = "Var ami_type must be one of \"AL2_x86_64\", \"AL2_x86_64_GPU\", \"AL2_ARM_64\" and  \"AL2023_x86_64_standard\"."
   }
 }
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
--> Added changes for AL2023 worker node AMI based on version tag v1.0.0.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->     Currently, there are no changes for AL2023, even in the latest tag 2.12.0. The necessary modifications for AL2023 EKS worker nodes are not present.
    The existing EKS nodes running Amazon Linux 2 have multiple vulnerabilities. To remediate these issues, we need to upgrade our EKS worker nodes to AL2023 worker nodes.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->     We have tested these changes in our infrastructure, and they are working well.
    We request that these changes be merged and released as a new tag, 1.0.1, which will include all the updates up to tag 1.0.0, along with the changes for AL2023 worker nodes.
