### PR TITLE
[bugfix]`random_pet` uses `kubernetes_version` as a string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "random_pet" "cbd" {
     # If `var.replace_node_group_on_version_update` is set to `true`, the Node Groups will be replaced instead of updated in-place
     var.replace_node_group_on_version_update ?
     {
-      version = var.kubernetes_version
+      version = var.kubernetes_version[0]
     } : {}
   )
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- Fixing a bug for `random_pet` keepers
- Update required terraform version to handle `strcontains`

## why

-   `random_pet` uses `kubernetes_version` as a string, but the variable is a list of strings, so extracting the first element is enough.


## references
- closes https://github.com/cloudposse/terraform-aws-eks-node-group/issues/188
- https://github.com/hashicorp/terraform/blob/v1.5/CHANGELOG.md#150-june-12-2023
