### PR TITLE
feat: enable node auto-repair by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -475,7 +475,7 @@ variable "node_group_terraform_timeouts" {
 
 variable "node_repair_enabled" {
   type        = bool
-  description = "The node auto-repair configuration for the node group will be enabled. Defaults to false"
+  description = "The node auto-repair configuration for the node group will be enabled. Defaults to true"
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -476,7 +476,7 @@ variable "node_group_terraform_timeouts" {
 variable "node_repair_enabled" {
   type        = bool
   description = "The node auto-repair configuration for the node group will be enabled. Defaults to false"
-  default     = false
+  default     = true
 }
 
 variable "detailed_monitoring_enabled" {


### PR DESCRIPTION
## what

The node auto-repair configuration for the node group will be enabled by default.

## why

This is a best practice.

## references

DEV-3756